### PR TITLE
Optimize route addition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- [#3](https://github.com/mezzio/mezzio-router/pull/3) adds a new class, `Mezzio\Router\DuplicateRouteDetector`, which improves performance of duplicate route detection dramatically.
 
 ### Changed
 
-- Nothing.
+- [#3](https://github.com/mezzio/mezzio-router/pull/3) changes the constructor of the `Mezzio\Router\RouteCollector` class to allow passing an optional flag (enabled by default) indicating whether or not to perform duplicate route detection. Internally, when the flag is enabled, the collector instantiates and memoizes a `DuplicateRouteDetector` on the addition of the first route.
+
+- [#3](https://github.com/mezzio/mezzio-router/pull/3) changes the `Mezzio\Router\RouteCollectorFactory` behavior to optionally look for a `Mezzio\Router\RouteCollector.detect_duplicates` flag in the `config` service; if found, the value is used when instantiating the `RouteCollector` instance.
 
 ### Deprecated
 
@@ -21,16 +23,6 @@ All notable changes to this project will be documented in this file, in reverse 
 - Nothing.
 
 ### Fixed
-
-- Nothing.
-
-## 3.2.1 - TBD
-
-### Added
-
-- Nothing.
-
-### Changed
 
 - Nothing.
 

--- a/src/DuplicateRouteDetector.php
+++ b/src/DuplicateRouteDetector.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * @see       https://github.com/mezzio/mezzio-router for the canonical source repository
+ * @copyright https://github.com/mezzio/mezzio-router/blob/master/COPYRIGHT.md
+ * @license   https://github.com/mezzio/mezzio-router/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Mezzio\Router;
+
+final class DuplicateRouteDetector
+{
+    private const ROUTE_SEARCH_ANY = 'any';
+    private const ROUTE_SEARCH_METHODS = 'methods';
+
+    /**
+     * List of all routes indexed by name
+     *
+     * @var Route[]
+     */
+    private $routeNames = [];
+
+    /**
+     * Search structure for duplicate path-method detection
+     * Indexed by path + method. Leaves are instances of Route
+     *  [
+     *      '/path/foo' => [
+     *          'methods' => [
+     *              'GET' => $route1,
+     *              'POST' => $route2,
+     *          ],
+     *      ],
+     *      '/path/bar' => [ 'any' => $route3 ],
+     *  ]
+     *
+     * @var array
+     */
+    private $routePaths = [];
+
+    /**
+     * Determine if the route is duplicated in the current list.
+     *
+     * Checks if a route with the same name or path exists already in the list;
+     * if so, and it responds to any of the $methods indicated, raises
+     * a DuplicateRouteException indicating a duplicate route.
+     *
+     * @throws Exception\DuplicateRouteException on duplicate route detection.
+     */
+    public function detectDuplicate(Route $route): void
+    {
+        $this->throwOnDuplicate($route);
+        $this->remember($route);
+    }
+
+    private function remember(Route $route): void
+    {
+        $this->routeNames[$route->getName()] = $route;
+        if ($route->allowsAnyMethod()) {
+            $this->routePaths[$route->getPath()][self::ROUTE_SEARCH_ANY] = $route;
+        }
+
+        $allowedMethods = $route->getAllowedMethods() ?? [];
+        foreach ($allowedMethods as $allowedMethod) {
+            $this->routePaths[$route->getPath()][self::ROUTE_SEARCH_METHODS][$allowedMethod] = $route;
+        }
+    }
+
+    private function throwOnDuplicate(Route $route): void
+    {
+        if (isset($this->routeNames[$route->getName()])) {
+            $this->duplicateRouteDetected($route);
+        }
+
+        if (! isset($this->routePaths[$route->getPath()])) {
+            return;
+        }
+
+        if (isset($this->routePaths[$route->getPath()][self::ROUTE_SEARCH_ANY])) {
+            $this->duplicateRouteDetected($route);
+        }
+
+        if ($route->allowsAnyMethod() && isset($this->routePaths[$route->getPath()][self::ROUTE_SEARCH_METHODS])) {
+            $this->duplicateRouteDetected($route);
+        }
+
+        $allowedMethods = $route->getAllowedMethods() ?? [];
+        foreach ($allowedMethods as $method) {
+            if (isset($this->routePaths[$route->getPath()][self::ROUTE_SEARCH_METHODS][$method])) {
+                $this->duplicateRouteDetected($route);
+            }
+        }
+    }
+
+    private function duplicateRouteDetected(Route $duplicate): void
+    {
+        $allowedMethods = $duplicate->getAllowedMethods() ?: [ '(any)' ];
+        $name = $duplicate->getName();
+        throw new Exception\DuplicateRouteException(
+            sprintf(
+                'Duplicate route detected; path "%s" answering to methods [%s]%s',
+                $duplicate->getPath(),
+                implode(',', $allowedMethods),
+                $name ? sprintf(', with name "%s"', $name) : ''
+            )
+        );
+    }
+}

--- a/src/DuplicateRouteDetector.php
+++ b/src/DuplicateRouteDetector.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @see       https://github.com/mezzio/mezzio-router for the canonical source repository
  * @copyright https://github.com/mezzio/mezzio-router/blob/master/COPYRIGHT.md
@@ -9,9 +10,12 @@ declare(strict_types=1);
 
 namespace Mezzio\Router;
 
+use function implode;
+use function sprintf;
+
 final class DuplicateRouteDetector
 {
-    private const ROUTE_SEARCH_ANY = 'any';
+    private const ROUTE_SEARCH_ANY     = 'any';
     private const ROUTE_SEARCH_METHODS = 'methods';
 
     /**
@@ -45,7 +49,7 @@ final class DuplicateRouteDetector
      * if so, and it responds to any of the $methods indicated, raises
      * a DuplicateRouteException indicating a duplicate route.
      *
-     * @throws Exception\DuplicateRouteException on duplicate route detection.
+     * @throws Exception\DuplicateRouteException On duplicate route detection.
      */
     public function detectDuplicate(Route $route): void
     {
@@ -94,8 +98,8 @@ final class DuplicateRouteDetector
 
     private function duplicateRouteDetected(Route $duplicate): void
     {
-        $allowedMethods = $duplicate->getAllowedMethods() ?: [ '(any)' ];
-        $name = $duplicate->getName();
+        $allowedMethods = $duplicate->getAllowedMethods() ?: ['(any)'];
+        $name           = $duplicate->getName();
         throw new Exception\DuplicateRouteException(
             sprintf(
                 'Duplicate route detected; path "%s" answering to methods [%s]%s',

--- a/src/Route.php
+++ b/src/Route.php
@@ -130,14 +130,15 @@ class Route implements MiddlewareInterface
     public function allowsMethod(string $method): bool
     {
         $method = strtoupper($method);
-        if (
-            $this->methods === self::HTTP_METHOD_ANY
-            || in_array($method, $this->methods, true)
-        ) {
-            return true;
-        }
+        return $this->allowsAnyMethod() || in_array($method, $this->methods, true);
+    }
 
-        return false;
+    /**
+     * Indicate whether any method is allowed by the route.
+     */
+    public function allowsAnyMethod(): bool
+    {
+        return $this->methods === self::HTTP_METHOD_ANY;
     }
 
     public function setOptions(array $options): void

--- a/src/RouteCollector.php
+++ b/src/RouteCollector.php
@@ -50,9 +50,15 @@ class RouteCollector
      */
     private $routes = [];
 
+    /**
+     * @var DuplicateRouteDetector
+     */
+    private $duplicateRouteDetector;
+
     public function __construct(RouterInterface $router)
     {
         $this->router = $router;
+        $this->duplicateRouteDetector = new DuplicateRouteDetector();
     }
 
     /**
@@ -70,11 +76,9 @@ class RouteCollector
         ?array $methods = null,
         ?string $name = null
     ): Route {
-        $this->checkForDuplicateRoute($path, $methods);
-
         $methods = $methods ?? Route::HTTP_METHOD_ANY;
         $route   = new Route($path, $middleware, $methods, $name);
-
+        $this->duplicateRouteDetector->detectDuplicate($route);
         $this->routes[] = $route;
         $this->router->addRoute($route);
 
@@ -137,47 +141,5 @@ class RouteCollector
     public function getRoutes(): array
     {
         return $this->routes;
-    }
-
-    /**
-     * Determine if the route is duplicated in the current list.
-     *
-     * Checks if a route with the same name or path exists already in the list;
-     * if so, and it responds to any of the $methods indicated, raises
-     * a DuplicateRouteException indicating a duplicate route.
-     *
-     * @throws Exception\DuplicateRouteException On duplicate route detection.
-     */
-    private function checkForDuplicateRoute(string $path, ?array $methods = null): void
-    {
-        if (null === $methods) {
-            $methods = Route::HTTP_METHOD_ANY;
-        }
-
-        $matches = array_filter($this->routes, function (Route $route) use ($path, $methods) {
-            if ($path !== $route->getPath()) {
-                return false;
-            }
-
-            if ($methods === Route::HTTP_METHOD_ANY) {
-                return true;
-            }
-
-            return array_reduce($methods, function ($carry, $method) use ($route) {
-                return $carry || $route->allowsMethod($method);
-            }, false);
-        });
-
-        if (! empty($matches)) {
-            $match          = reset($matches);
-            $allowedMethods = $match->getAllowedMethods() ?: ['(any)'];
-            $name           = $match->getName();
-            throw new Exception\DuplicateRouteException(sprintf(
-                'Duplicate route detected; path "%s" answering to methods [%s]%s',
-                $match->getPath(),
-                implode(',', $allowedMethods),
-                $name ? sprintf(', with name "%s"', $name) : ''
-            ));
-        }
     }
 }

--- a/src/RouteCollector.php
+++ b/src/RouteCollector.php
@@ -43,6 +43,9 @@ class RouteCollector
     /** @var RouterInterface */
     protected $router;
 
+    /** @var bool */
+    protected $detectDuplicates = true;
+
     /**
      * List of all routes registered directly with the application.
      *
@@ -51,14 +54,14 @@ class RouteCollector
     private $routes = [];
 
     /**
-     * @var DuplicateRouteDetector
+     * @var null|DuplicateRouteDetector
      */
     private $duplicateRouteDetector;
 
-    public function __construct(RouterInterface $router)
+    public function __construct(RouterInterface $router, bool $detectDuplicates = true)
     {
         $this->router = $router;
-        $this->duplicateRouteDetector = new DuplicateRouteDetector();
+        $this->detectDuplicates = $detectDuplicates;
     }
 
     /**
@@ -78,7 +81,7 @@ class RouteCollector
     ): Route {
         $methods = $methods ?? Route::HTTP_METHOD_ANY;
         $route   = new Route($path, $middleware, $methods, $name);
-        $this->duplicateRouteDetector->detectDuplicate($route);
+        $this->detectDuplicate($route);
         $this->routes[] = $route;
         $this->router->addRoute($route);
 
@@ -141,5 +144,17 @@ class RouteCollector
     public function getRoutes(): array
     {
         return $this->routes;
+    }
+
+    private function detectDuplicate(Route $route): void
+    {
+        if ($this->detectDuplicates && ! $this->duplicateRouteDetector) {
+            $this->duplicateRouteDetector = new DuplicateRouteDetector();
+        }
+
+        if ($this->duplicateRouteDetector) {
+            $this->duplicateRouteDetector->detectDuplicate($route);
+            return;
+        }
     }
 }

--- a/src/RouteCollector.php
+++ b/src/RouteCollector.php
@@ -12,12 +12,6 @@ namespace Mezzio\Router;
 
 use Psr\Http\Server\MiddlewareInterface;
 
-use function array_filter;
-use function array_reduce;
-use function implode;
-use function reset;
-use function sprintf;
-
 /**
  * Aggregate routes for the router.
  *
@@ -53,14 +47,12 @@ class RouteCollector
      */
     private $routes = [];
 
-    /**
-     * @var null|DuplicateRouteDetector
-     */
+    /** @var null|DuplicateRouteDetector */
     private $duplicateRouteDetector;
 
     public function __construct(RouterInterface $router, bool $detectDuplicates = true)
     {
-        $this->router = $router;
+        $this->router           = $router;
         $this->detectDuplicates = $detectDuplicates;
     }
 

--- a/src/RouteCollectorFactory.php
+++ b/src/RouteCollectorFactory.php
@@ -42,7 +42,27 @@ class RouteCollectorFactory
         return new RouteCollector(
             $container->has(RouterInterface::class)
                 ? $container->get(RouterInterface::class)
-                : $container->get(ZendExpressiveRouterInterface::class)
+                : $container->get(ZendExpressiveRouterInterface::class),
+            $this->getDetectDuplicatesFlag($container)
         );
+    }
+
+    private function getDetectDuplicatesFlag(ContainerInterface $container): bool
+    {
+        if (! $container->has('config')) {
+            return true;
+        }
+
+        $config = $container->get('config');
+        if (! array_key_exists(RouteCollector::class, $config)) {
+            return true;
+        }
+
+        $config = $config[RouteCollector::class];
+        if (! array_key_exists('detect_duplicates', $config)) {
+            return true;
+        }
+
+        return (bool) $config['detect_duplicates'];
     }
 }

--- a/src/RouteCollectorFactory.php
+++ b/src/RouteCollectorFactory.php
@@ -13,6 +13,8 @@ namespace Mezzio\Router;
 use Psr\Container\ContainerInterface;
 use Zend\Expressive\Router\RouterInterface as ZendExpressiveRouterInterface;
 
+use function array_key_exists;
+
 /**
  * Create and return a RouteCollector instance.
  *

--- a/src/Test/AbstractImplicitMethodsIntegrationTest.php
+++ b/src/Test/AbstractImplicitMethodsIntegrationTest.php
@@ -178,6 +178,9 @@ abstract class AbstractImplicitMethodsIntegrationTest extends TestCase
         $this->assertSame('baz', $response->getHeaderLine('foo-bar'));
     }
 
+    /**
+     * @return iterable
+     */
     public function withoutImplicitMiddleware()
     {
         // @codingStandardsIgnoreStart

--- a/test/RouteCollectorTest.php
+++ b/test/RouteCollectorTest.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 namespace MezzioTest\Router;
 
 use Fig\Http\Message\RequestMethodInterface as RequestMethod;
-use Mezzio\Router\DuplicateRouteDetector;
 use Mezzio\Router\Exception;
 use Mezzio\Router\Route;
 use Mezzio\Router\RouteCollector;
@@ -55,6 +54,7 @@ class RouteCollectorTest extends TestCase
     public function createNoopMiddleware(): MiddlewareInterface
     {
         return new class ($this->response->reveal()) implements MiddlewareInterface {
+            /** @var ResponseInterface */
             private $response;
 
             public function __construct(ResponseInterface $response)
@@ -223,7 +223,7 @@ class RouteCollectorTest extends TestCase
         foreach (range(1, 10) as $item) {
             $this->collector->get("/bar$item", $this->noopMiddleware);
         }
-        $baseDuration = microtime(true) - $start;
+        $baseDuration    = microtime(true) - $start;
         $this->collector = new RouteCollector($this->router->reveal());
 
         $start = microtime(true);
@@ -231,9 +231,9 @@ class RouteCollectorTest extends TestCase
             $this->collector->get("/foo$item", $this->noopMiddleware);
         }
 
-        $duration = microtime(true) - $start;
+        $duration         = microtime(true) - $start;
         $expectedDuration = $baseDuration * 1000;
-        $error = 30 * $expectedDuration / 100;
+        $error            = 30 * $expectedDuration / 100;
         $this->assertTrue(
             $expectedDuration + $error > $duration,
             sprintf(
@@ -248,7 +248,7 @@ class RouteCollectorTest extends TestCase
 
     public function testCreatingHttpRouteWithExistingPathAndMethodRaisesException()
     {
-        $this->router->addRoute(Argument::type(\Zend\Expressive\Router\Route::class))->shouldBeCalledTimes(1);
+        $this->router->addRoute(Argument::type(Route::class))->shouldBeCalledTimes(1);
         $this->collector->get('/foo', $this->noopMiddleware, 'route1');
 
         $this->expectException(Exception\DuplicateRouteException::class);
@@ -297,7 +297,7 @@ class RouteCollectorTest extends TestCase
     public function testCreatingHttpRouteWithExistingNameDoesNotRaiseExceptionIfDuplicateDetectionDisabled()
     {
         $this->router->addRoute(Argument::type(Route::class))->shouldBeCalledTimes(2);
-        $collector      = new RouteCollector($this->router->reveal(), false);
+        $collector = new RouteCollector($this->router->reveal(), false);
         $collector->get('/foo', $this->noopMiddleware, 'duplicate');
         $collector->get('/foo/baz', $this->createNoopMiddleware(), 'duplicate');
 

--- a/test/RouteCollectorTest.php
+++ b/test/RouteCollectorTest.php
@@ -293,4 +293,14 @@ class RouteCollectorTest extends TestCase
 
         $this->collector->get('/foo/baz', $this->createNoopMiddleware(), 'duplicate');
     }
+
+    public function testCreatingHttpRouteWithExistingNameDoesNotRaiseExceptionIfDuplicateDetectionDisabled()
+    {
+        $this->router->addRoute(Argument::type(Route::class))->shouldBeCalledTimes(2);
+        $collector      = new RouteCollector($this->router->reveal(), false);
+        $collector->get('/foo', $this->noopMiddleware, 'duplicate');
+        $collector->get('/foo/baz', $this->createNoopMiddleware(), 'duplicate');
+
+        $this->assertCount(2, $collector->getRoutes());
+    }
 }

--- a/test/RouteCollectorTest.php
+++ b/test/RouteCollectorTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace MezzioTest\Router;
 
 use Fig\Http\Message\RequestMethodInterface as RequestMethod;
+use Mezzio\Router\DuplicateRouteDetector;
 use Mezzio\Router\Exception;
 use Mezzio\Router\Route;
 use Mezzio\Router\RouteCollector;
@@ -25,6 +26,9 @@ use Psr\Http\Server\RequestHandlerInterface;
 use TypeError;
 
 use function array_keys;
+use function microtime;
+use function range;
+use function sprintf;
 
 class RouteCollectorTest extends TestCase
 {
@@ -189,15 +193,6 @@ class RouteCollectorTest extends TestCase
         $this->assertSame($middleware, $test->getMiddleware());
     }
 
-    public function testCreatingHttpRouteWithExistingPathAndMethodRaisesException()
-    {
-        $this->router->addRoute(Argument::type(Route::class))->shouldBeCalledTimes(1);
-        $this->collector->get('/foo', $this->noopMiddleware);
-
-        $this->expectException(Exception\DuplicateRouteException::class);
-        $this->collector->get('/foo', $this->createNoopMiddleware());
-    }
-
     public function testGetRoutes()
     {
         $middleware1 = $this->prophesize(MiddlewareInterface::class)->reveal();
@@ -220,5 +215,82 @@ class RouteCollectorTest extends TestCase
         $this->assertSame($middleware2, $routes[1]->getMiddleware());
         $this->assertSame('def', $routes[1]->getName());
         $this->assertSame([RequestMethod::METHOD_GET], $routes[1]->getAllowedMethods());
+    }
+
+    public function testCreatingHttpRouteWithExistingPathShouldBeLinear()
+    {
+        $start = microtime(true);
+        foreach (range(1, 10) as $item) {
+            $this->collector->get("/bar$item", $this->noopMiddleware);
+        }
+        $baseDuration = microtime(true) - $start;
+        $this->collector = new RouteCollector($this->router->reveal());
+
+        $start = microtime(true);
+        foreach (range(1, 10000) as $item) {
+            $this->collector->get("/foo$item", $this->noopMiddleware);
+        }
+
+        $duration = microtime(true) - $start;
+        $expectedDuration = $baseDuration * 1000;
+        $error = 30 * $expectedDuration / 100;
+        $this->assertTrue(
+            $expectedDuration + $error > $duration,
+            sprintf(
+                'Route add time should be linear by amount of routes,'
+                . ' expected duration: %s, possible error: %s, actual duration: %s',
+                $expectedDuration,
+                $error,
+                $duration
+            )
+        );
+    }
+
+    public function testCreatingHttpRouteWithExistingPathAndMethodRaisesException()
+    {
+        $this->router->addRoute(Argument::type(\Zend\Expressive\Router\Route::class))->shouldBeCalledTimes(1);
+        $this->collector->get('/foo', $this->noopMiddleware, 'route1');
+
+        $this->expectException(Exception\DuplicateRouteException::class);
+        $message = 'Duplicate route detected; path "/foo" answering to methods [GET], with name "route2"';
+        $this->expectExceptionMessage($message);
+
+        $this->collector->get('/foo', $this->createNoopMiddleware(), 'route2');
+    }
+
+    public function testCheckDuplicateRouteWhenExistsRouteForAnyMethods()
+    {
+        $this->router->addRoute(Argument::type(Route::class))->shouldBeCalledTimes(1);
+        $this->collector->any('/foo', $this->noopMiddleware, 'route1');
+
+        $this->expectException(Exception\DuplicateRouteException::class);
+        $message = 'Duplicate route detected; path "/foo" answering to methods [GET], with name "route2"';
+        $this->expectExceptionMessage($message);
+
+        $this->collector->get('/foo', $this->createNoopMiddleware(), 'route2');
+    }
+
+    public function testCheckDuplicateRouteWhenExistsRouteForGetMethodsAndAddingRouteForAnyMethod()
+    {
+        $this->router->addRoute(Argument::type(Route::class))->shouldBeCalledTimes(1);
+        $this->collector->get('/foo', $this->noopMiddleware, 'route1');
+
+        $this->expectException(Exception\DuplicateRouteException::class);
+        $message = 'Duplicate route detected; path "/foo" answering to methods [(any)], with name "route2"';
+        $this->expectExceptionMessage($message);
+
+        $this->collector->any('/foo', $this->createNoopMiddleware(), 'route2');
+    }
+
+    public function testCreatingHttpRouteWithExistingNameRaisesException()
+    {
+        $this->router->addRoute(Argument::type(Route::class))->shouldBeCalledTimes(1);
+        $this->collector->get('/foo', $this->noopMiddleware, 'duplicate');
+
+        $this->expectException(Exception\DuplicateRouteException::class);
+        $message = 'Duplicate route detected; path "/foo/baz" answering to methods [GET], with name "duplicate"';
+        $this->expectExceptionMessage($message);
+
+        $this->collector->get('/foo/baz', $this->createNoopMiddleware(), 'duplicate');
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | yes
| New Feature   | no
| RFC           | no
| QA            | no

### Description

This pr optimizes route addition by removing O(n) duplicate check. In case of big monolitic application this starts to bite performance of application initialization. I have moved duplication check to separate class because now it owns hashmap data structure for searching route.

Solves #1 