### PR TITLE
Nullability of Route::__construct() arguments missing ?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,12 @@ matrix:
     - php: 7.3
       env:
         - DEPS=latest
+    - php: 7.4
+      env:
+        - DEPS=lowest
+    - php: 7.4
+      env:
+        - DEPS=latest
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "php": "^7.1",
         "fig/http-message-util": "^1.1.2",
         "laminas/laminas-zendframework-bridge": "^1.0",
+        "phpspec/prophecy": "^1.9",
         "psr/container": "^1.0",
         "psr/http-message": "^1.0.1",
         "psr/http-server-middleware": "^1.0"

--- a/src/Route.php
+++ b/src/Route.php
@@ -78,8 +78,8 @@ class Route implements MiddlewareInterface
     public function __construct(
         string $path,
         MiddlewareInterface $middleware,
-        array $methods = self::HTTP_METHOD_ANY,
-        string $name = null
+        ?array $methods = self::HTTP_METHOD_ANY,
+        ?string $name = null
     ) {
         $this->path       = $path;
         $this->middleware = $middleware;

--- a/test/RouteTest.php
+++ b/test/RouteTest.php
@@ -158,7 +158,7 @@ class RouteTest extends TestCase
     public function testThrowsExceptionDuringConstructionOnInvalidHttpMethod()
     {
         $this->expectException(TypeError::class);
-        $this->expectExceptionMessage('must be of the type array, string given');
+        $this->expectExceptionMessage('must be of the type array or null, string given');
 
         new Route('/foo', $this->noopMiddleware, 'FOO');
     }


### PR DESCRIPTION
- Add 7.4 to build matrix
- Add nullability type hint to Route::__construct for arguments $methods and $name
- Alter expected Type error message to include null in RouteTest

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | yes
| QA            | no

### Description

The missing nullable type in Route::__construct() for the $methods param has just bitten me on 7.4 and 8.0.
