### PR TITLE
Remove verbiage around raising an exception from `RouterInterface::addRoute()`

### DIFF
--- a/src/RouterInterface.php
+++ b/src/RouterInterface.php
@@ -26,13 +26,6 @@ interface RouterInterface
      * `generateUri()` is called.  This is required to allow consumers to
      * modify route instances before matching (e.g., to provide route options,
      * inject a name, etc.).
-     *
-     * The method MUST raise Exception\RuntimeException if called after either `match()`
-     * or `generateUri()` have already been called, to ensure integrity of the
-     * router between invocations of either of those methods.
-     *
-     * @throws Exception\RuntimeException when called after match() or
-     *     generateUri() have been called.
      */
     public function addRoute(Route $route) : void;
 


### PR DESCRIPTION
Ports zendframework/zend-expressive-router#77 to mezzio-router; see https://github.com/zendframework/zend-expressive-router/pull/77#issuecomment-427844516 for details on the original decision to do this.

Essentially, the verbiage is unnecessary with how we've actually implemented routers. Removing the verbiage leaves how implementations choose to handle conditions where the method is called after URI generation and route matching up to them.

Fixes #2