### PR TITLE
Restore renamed abstract ImplicitMethodsIntegrationTest class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,10 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Deprecated
 
-- Nothing.
+- [#11](https://github.com/mezzio/mezzio-router/pull/11)
+  deprecates the class `\Mezzio\Router\Test\ImplicitMethodsIntegrationTest`,
+  as it will be removed in the next versions. Use new renamed class
+  `\Mezzio\Router\Test\AbstractImplicitMethodsIntegrationTest` instead.
 
 ### Removed
 

--- a/src/Test/ImplicitMethodsIntegrationTest.php
+++ b/src/Test/ImplicitMethodsIntegrationTest.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @see       https://github.com/mezzio/mezzio-router for the canonical source repository
+ * @copyright https://github.com/mezzio/mezzio-router/blob/master/COPYRIGHT.md
+ * @license   https://github.com/mezzio/mezzio-router/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Mezzio\Router\Test;
+
+// phpcs:ignoreFile
+
+/**
+ * @deprecated Use AbstractImplicitMethodsIntegrationTest instead
+ */
+abstract class ImplicitMethodsIntegrationTest extends AbstractImplicitMethodsIntegrationTest
+{
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description
Restore wrongly renamend `ImplicitMethodsIntegrationTest` class
