### PR TITLE
Psalm integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ script:
   - if [[ $TEST_COVERAGE == 'true' ]]; then composer test-coverage ; else composer test ; fi
   - if [[ $CS_CHECK == 'true' ]]; then composer cs-check ; fi
   - if [[ $CS_CHECK == 'true' ]]; then composer license-check ; fi
+  - if [[ $TEST_COVERAGE == 'true' ]]; then composer static-analysis ; fi
 
 after_script:
   - if [[ $TEST_COVERAGE == 'true' ]]; then vendor/bin/php-coveralls -v ; fi

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,9 @@
         "laminas/laminas-coding-standard": "~2.1.0",
         "malukenho/docheader": "^0.1.6",
         "phpspec/prophecy": "^1.9",
-        "phpunit/phpunit": "^9.4.1"
+        "phpunit/phpunit": "^9.4.1",
+        "psalm/plugin-phpunit": "^0.15.0",
+        "vimeo/psalm": "^4.3"
     },
     "suggest": {
         "mezzio/mezzio-aurarouter": "^3.0 to use the Aura.Router routing adapter",
@@ -64,6 +66,7 @@
         ],
         "cs-check": "phpcs",
         "cs-fix": "phpcbf",
+        "static-analysis": "psalm --shepherd --stats",
         "test": "phpunit --colors=always",
         "test-coverage": "phpunit --colors=always --coverage-clover clover.xml",
         "license-check": "docheader check src/ test/"

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
         "laminas/laminas-coding-standard": "~2.1.0",
         "malukenho/docheader": "^0.1.6",
         "phpspec/prophecy": "^1.9",
+        "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpunit": "^9.4.1",
         "psalm/plugin-phpunit": "^0.15.0",
         "vimeo/psalm": "^4.3"

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,0 +1,704 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="4.3.2@57b53ff26237074fdf5cbcb034f7da5172be4524">
+  <file src="src/DuplicateRouteDetector.php">
+    <MixedArrayAssignment occurrences="2">
+      <code>$this-&gt;routePaths[$route-&gt;getPath()][self::ROUTE_SEARCH_ANY]</code>
+      <code>$this-&gt;routePaths[$route-&gt;getPath()][self::ROUTE_SEARCH_METHODS]</code>
+    </MixedArrayAssignment>
+  </file>
+  <file src="src/Middleware/DispatchMiddleware.php">
+    <MixedAssignment occurrences="1">
+      <code>$routeResult</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="1">
+      <code>ResponseInterface</code>
+    </MixedInferredReturnType>
+    <MixedMethodCall occurrences="1">
+      <code>process</code>
+    </MixedMethodCall>
+    <MixedReturnStatement occurrences="1">
+      <code>$routeResult-&gt;process($request, $handler)</code>
+    </MixedReturnStatement>
+  </file>
+  <file src="src/Middleware/ImplicitHeadMiddleware.php">
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>$param</code>
+    </MixedArgumentTypeCoercion>
+    <MixedAssignment occurrences="2">
+      <code>$result</code>
+      <code>$value</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="1">
+      <code>StreamInterface</code>
+    </MixedInferredReturnType>
+    <MixedMethodCall occurrences="1">
+      <code>getMatchedRoute</code>
+    </MixedMethodCall>
+    <MixedReturnStatement occurrences="1">
+      <code>$streamFactory()</code>
+    </MixedReturnStatement>
+  </file>
+  <file src="src/Middleware/ImplicitHeadMiddlewareFactory.php">
+    <MixedArgument occurrences="2">
+      <code>$container-&gt;get(StreamInterface::class)</code>
+    </MixedArgument>
+  </file>
+  <file src="src/Middleware/ImplicitOptionsMiddleware.php">
+    <MixedArgument occurrences="1">
+      <code>$allowedMethods</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="2">
+      <code>$allowedMethods</code>
+      <code>$result</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="2">
+      <code>ResponseInterface</code>
+      <code>ResponseInterface</code>
+    </MixedInferredReturnType>
+    <MixedMethodCall occurrences="5">
+      <code>getAllowedMethods</code>
+      <code>getMatchedRoute</code>
+      <code>isFailure</code>
+      <code>isMethodFailure</code>
+      <code>withHeader</code>
+    </MixedMethodCall>
+    <MixedReturnStatement occurrences="2">
+      <code>$responseFactory()</code>
+      <code>($this-&gt;responseFactory)()-&gt;withHeader('Allow', implode(',', $allowedMethods))</code>
+    </MixedReturnStatement>
+  </file>
+  <file src="src/Middleware/ImplicitOptionsMiddlewareFactory.php">
+    <MixedArgument occurrences="1">
+      <code>$container-&gt;get(ResponseInterface::class)</code>
+    </MixedArgument>
+  </file>
+  <file src="src/Middleware/MethodNotAllowedMiddleware.php">
+    <MixedArgument occurrences="1">
+      <code>$routeResult-&gt;getAllowedMethods()</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="1">
+      <code>$routeResult</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="2">
+      <code>ResponseInterface</code>
+      <code>ResponseInterface</code>
+    </MixedInferredReturnType>
+    <MixedMethodCall occurrences="4">
+      <code>getAllowedMethods</code>
+      <code>isMethodFailure</code>
+      <code>withHeader</code>
+      <code>withStatus</code>
+    </MixedMethodCall>
+    <MixedReturnStatement occurrences="2">
+      <code>$responseFactory()</code>
+    </MixedReturnStatement>
+  </file>
+  <file src="src/Middleware/MethodNotAllowedMiddlewareFactory.php">
+    <MixedArgument occurrences="1">
+      <code>$container-&gt;get(ResponseInterface::class)</code>
+    </MixedArgument>
+  </file>
+  <file src="src/Middleware/RouteMiddleware.php">
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>$param</code>
+    </MixedArgumentTypeCoercion>
+    <MixedAssignment occurrences="1">
+      <code>$value</code>
+    </MixedAssignment>
+  </file>
+  <file src="src/Middleware/RouteMiddlewareFactory.php">
+    <MixedArgument occurrences="2">
+      <code>$container-&gt;get($this-&gt;routerServiceName)</code>
+      <code>$data['routerServiceName'] ?? RouterInterface::class</code>
+    </MixedArgument>
+  </file>
+  <file src="src/Route.php">
+    <MissingClosureParamType occurrences="2">
+      <code>$method</code>
+      <code>$valid</code>
+    </MissingClosureParamType>
+    <PossiblyNullArgument occurrences="1">
+      <code>$this-&gt;methods</code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="src/RouteCollector.php">
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>$methods</code>
+    </MixedArgumentTypeCoercion>
+  </file>
+  <file src="src/RouteCollectorFactory.php">
+    <MixedArgument occurrences="3">
+      <code>$config</code>
+      <code>$config</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="2">
+      <code>$config</code>
+      <code>$config</code>
+    </MixedAssignment>
+  </file>
+  <file src="src/RouteResult.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>[]</code>
+    </DocblockTypeContradiction>
+    <MixedPropertyTypeCoercion occurrences="1">
+      <code>$methods</code>
+    </MixedPropertyTypeCoercion>
+    <PossiblyFalseReference occurrences="1">
+      <code>process</code>
+    </PossiblyFalseReference>
+    <PossiblyNullReference occurrences="1">
+      <code>process</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>$matchedRouteName</code>
+      <code>$route</code>
+      <code>$success</code>
+    </PropertyNotSetInConstructor>
+    <RedundantConditionGivenDocblockType occurrences="2">
+      <code>! $this-&gt;matchedRouteName &amp;&amp; $this-&gt;route</code>
+      <code>$this-&gt;route</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="src/Test/AbstractImplicitMethodsIntegrationTest.php">
+    <MissingClosureReturnType occurrences="2">
+      <code>function () use ($response) {</code>
+      <code>function () {</code>
+    </MissingClosureReturnType>
+    <MixedArgumentTypeCoercion occurrences="2">
+      <code>[$routeMethod]</code>
+      <code>[$routeMethod]</code>
+    </MixedArgumentTypeCoercion>
+    <MixedAssignment occurrences="19">
+      <code>$finalResponse</code>
+      <code>$finalResponse</code>
+      <code>$finalResponse</code>
+      <code>$pipeline</code>
+      <code>$pipeline</code>
+      <code>$pipeline</code>
+      <code>$pipeline</code>
+      <code>$pipeline</code>
+      <code>$request</code>
+      <code>$request</code>
+      <code>$request</code>
+      <code>$request</code>
+      <code>$request</code>
+      <code>$response</code>
+      <code>$response</code>
+      <code>$response</code>
+      <code>$routeMethod</code>
+      <code>$routeMethod</code>
+      <code>$value</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="3">
+      <code>Generator</code>
+      <code>Generator</code>
+      <code>iterable</code>
+    </MixedInferredReturnType>
+    <MixedMethodCall occurrences="43">
+      <code>getBody</code>
+      <code>getBody</code>
+      <code>getBody</code>
+      <code>getBody</code>
+      <code>getBody</code>
+      <code>getBody</code>
+      <code>getHeaderLine</code>
+      <code>getHeaderLine</code>
+      <code>getHeaderLine</code>
+      <code>getStatusCode</code>
+      <code>getStatusCode</code>
+      <code>getStatusCode</code>
+      <code>hasHeader</code>
+      <code>hasHeader</code>
+      <code>hasHeader</code>
+      <code>pipe</code>
+      <code>pipe</code>
+      <code>pipe</code>
+      <code>pipe</code>
+      <code>pipe</code>
+      <code>pipe</code>
+      <code>pipe</code>
+      <code>pipe</code>
+      <code>pipe</code>
+      <code>pipe</code>
+      <code>pipe</code>
+      <code>pipe</code>
+      <code>pipe</code>
+      <code>pipe</code>
+      <code>pipe</code>
+      <code>pipe</code>
+      <code>process</code>
+      <code>process</code>
+      <code>process</code>
+      <code>process</code>
+      <code>process</code>
+      <code>withHeader</code>
+      <code>withHeader</code>
+      <code>withHeader</code>
+      <code>withStatus</code>
+      <code>write</code>
+      <code>write</code>
+      <code>write</code>
+    </MixedMethodCall>
+    <UndefinedClass occurrences="15">
+      <code>MiddlewarePipe</code>
+      <code>MiddlewarePipe</code>
+      <code>MiddlewarePipe</code>
+      <code>MiddlewarePipe</code>
+      <code>MiddlewarePipe</code>
+      <code>Response</code>
+      <code>Response</code>
+      <code>Response</code>
+      <code>Response</code>
+      <code>ServerRequest</code>
+      <code>ServerRequest</code>
+      <code>ServerRequest</code>
+      <code>ServerRequest</code>
+      <code>ServerRequest</code>
+      <code>Stream</code>
+    </UndefinedClass>
+  </file>
+  <file src="test/ConfigProviderTest.php">
+    <MixedArgument occurrences="6">
+      <code>$factories</code>
+      <code>$factories</code>
+      <code>$factories</code>
+      <code>$factories</code>
+      <code>$factories</code>
+      <code>$factories</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="1">
+      <code>$factories</code>
+    </MixedAssignment>
+  </file>
+  <file src="test/Middleware/DispatchMiddlewareTest.php">
+    <InvalidArgument occurrences="1">
+      <code>Argument::any()</code>
+    </InvalidArgument>
+    <MixedArgument occurrences="5">
+      <code>$this-&gt;handler-&gt;reveal()</code>
+      <code>$this-&gt;handler-&gt;reveal()</code>
+      <code>$this-&gt;request-&gt;reveal()</code>
+      <code>$this-&gt;request-&gt;reveal()</code>
+      <code>$this-&gt;request-&gt;reveal()</code>
+    </MixedArgument>
+    <MixedMethodCall occurrences="2">
+      <code>will</code>
+      <code>willReturn</code>
+    </MixedMethodCall>
+    <PossiblyUndefinedMethod occurrences="7">
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>shouldNotBeCalled</code>
+      <code>willReturn</code>
+    </PossiblyUndefinedMethod>
+    <UndefinedMethod occurrences="2">
+      <code>[$this-&gt;handler, 'reveal']</code>
+      <code>[$this-&gt;request, 'reveal']</code>
+    </UndefinedMethod>
+  </file>
+  <file src="test/Middleware/ImplicitHeadMiddlewareFactoryTest.php">
+    <MixedArgument occurrences="3">
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+    </MixedArgument>
+    <MixedMethodCall occurrences="2">
+      <code>will</code>
+      <code>willReturn</code>
+    </MixedMethodCall>
+    <PossiblyInvalidMethodCall occurrences="6">
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+    </PossiblyInvalidMethodCall>
+    <PossiblyUndefinedMethod occurrences="3">
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+    </PossiblyUndefinedMethod>
+  </file>
+  <file src="test/Middleware/ImplicitHeadMiddlewareTest.php">
+    <InvalidArgument occurrences="3">
+      <code>$request</code>
+      <code>$request</code>
+      <code>$request</code>
+    </InvalidArgument>
+    <MissingClosureReturnType occurrences="1">
+      <code>function () {</code>
+    </MissingClosureReturnType>
+    <MixedArgument occurrences="4">
+      <code>$this-&gt;response-&gt;reveal()</code>
+      <code>$this-&gt;response-&gt;reveal()</code>
+      <code>$this-&gt;response-&gt;reveal()</code>
+      <code>$this-&gt;response-&gt;reveal()</code>
+    </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="2">
+      <code>[$request, 'reveal']</code>
+      <code>[$request, 'reveal']</code>
+    </MixedArgumentTypeCoercion>
+    <PossiblyUndefinedMethod occurrences="10">
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+    </PossiblyUndefinedMethod>
+    <UndefinedMethod occurrences="4">
+      <code>[$this-&gt;response, 'reveal']</code>
+      <code>[$this-&gt;response, 'reveal']</code>
+      <code>[$this-&gt;response, 'reveal']</code>
+      <code>[$this-&gt;response, 'reveal']</code>
+    </UndefinedMethod>
+  </file>
+  <file src="test/Middleware/ImplicitOptionsMiddlewareFactoryTest.php">
+    <MixedArgument occurrences="2">
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+    </MixedArgument>
+    <MixedMethodCall occurrences="1">
+      <code>willReturn</code>
+    </MixedMethodCall>
+    <PossiblyInvalidMethodCall occurrences="2">
+      <code>willReturn</code>
+      <code>willReturn</code>
+    </PossiblyInvalidMethodCall>
+    <PossiblyUndefinedMethod occurrences="2">
+      <code>reveal</code>
+      <code>reveal</code>
+    </PossiblyUndefinedMethod>
+  </file>
+  <file src="test/Middleware/ImplicitOptionsMiddlewareTest.php">
+    <MissingClosureReturnType occurrences="1">
+      <code>function () {</code>
+    </MissingClosureReturnType>
+    <MixedArgument occurrences="1">
+      <code>$this-&gt;response-&gt;reveal()</code>
+    </MixedArgument>
+    <PossiblyUndefinedMethod occurrences="3">
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>will</code>
+    </PossiblyUndefinedMethod>
+    <UndefinedMethod occurrences="1">
+      <code>[$this-&gt;response, 'reveal']</code>
+    </UndefinedMethod>
+  </file>
+  <file src="test/Middleware/MethodNotAllowedMiddlewareFactoryTest.php">
+    <MixedArgument occurrences="2">
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+    </MixedArgument>
+    <MixedMethodCall occurrences="1">
+      <code>willReturn</code>
+    </MixedMethodCall>
+    <PossiblyInvalidMethodCall occurrences="2">
+      <code>willReturn</code>
+      <code>willReturn</code>
+    </PossiblyInvalidMethodCall>
+    <PossiblyUndefinedMethod occurrences="2">
+      <code>reveal</code>
+      <code>reveal</code>
+    </PossiblyUndefinedMethod>
+  </file>
+  <file src="test/Middleware/MethodNotAllowedMiddlewareTest.php">
+    <ImplicitToStringCast occurrences="2">
+      <code>Argument::any()</code>
+      <code>Argument::any()</code>
+    </ImplicitToStringCast>
+    <InvalidArgument occurrences="5">
+      <code>Argument::any()</code>
+      <code>Argument::any()</code>
+      <code>Argument::that([$this-&gt;request, 'reveal'])</code>
+      <code>Argument::that([$this-&gt;request, 'reveal'])</code>
+      <code>Argument::that([$this-&gt;request, 'reveal'])</code>
+    </InvalidArgument>
+    <MissingClosureReturnType occurrences="1">
+      <code>function () {</code>
+    </MissingClosureReturnType>
+    <MixedArgument occurrences="9">
+      <code>$this-&gt;handler-&gt;reveal()</code>
+      <code>$this-&gt;handler-&gt;reveal()</code>
+      <code>$this-&gt;handler-&gt;reveal()</code>
+      <code>$this-&gt;request-&gt;reveal()</code>
+      <code>$this-&gt;request-&gt;reveal()</code>
+      <code>$this-&gt;request-&gt;reveal()</code>
+      <code>$this-&gt;response-&gt;reveal()</code>
+      <code>$this-&gt;response-&gt;reveal()</code>
+      <code>$this-&gt;response-&gt;reveal()</code>
+    </MixedArgument>
+    <MixedMethodCall occurrences="3">
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+    </MixedMethodCall>
+    <PossiblyUndefinedMethod occurrences="19">
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>shouldNotBeCalled</code>
+      <code>shouldNotBeCalled</code>
+      <code>shouldNotBeCalled</code>
+      <code>shouldNotBeCalled</code>
+      <code>shouldNotBeCalled</code>
+      <code>will</code>
+      <code>will</code>
+      <code>will</code>
+      <code>will</code>
+    </PossiblyUndefinedMethod>
+    <UndefinedMethod occurrences="7">
+      <code>[$this-&gt;request, 'reveal']</code>
+      <code>[$this-&gt;request, 'reveal']</code>
+      <code>[$this-&gt;request, 'reveal']</code>
+      <code>[$this-&gt;response, 'reveal']</code>
+      <code>[$this-&gt;response, 'reveal']</code>
+      <code>[$this-&gt;response, 'reveal']</code>
+      <code>[$this-&gt;response, 'reveal']</code>
+    </UndefinedMethod>
+  </file>
+  <file src="test/Middleware/RouteMiddlewareFactoryTest.php">
+    <MissingClosureReturnType occurrences="2">
+      <code>function () {</code>
+      <code>function () {</code>
+    </MissingClosureReturnType>
+    <MixedArgument occurrences="7">
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>Router::class</code>
+      <code>Router::class</code>
+      <code>Router::class</code>
+      <code>Router::class</code>
+    </MixedArgument>
+    <MixedMethodCall occurrences="2">
+      <code>willReturn</code>
+      <code>willReturn</code>
+    </MixedMethodCall>
+    <PossiblyInvalidFunctionCall occurrences="2"/>
+    <PossiblyInvalidMethodCall occurrences="4">
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+    </PossiblyInvalidMethodCall>
+    <PossiblyUndefinedMethod occurrences="3">
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+    </PossiblyUndefinedMethod>
+    <UndefinedClass occurrences="5">
+      <code>Router</code>
+      <code>Router</code>
+      <code>Router</code>
+      <code>Router</code>
+      <code>Router</code>
+    </UndefinedClass>
+    <UndefinedThisPropertyFetch occurrences="2">
+      <code>$this-&gt;router</code>
+      <code>$this-&gt;routerServiceName</code>
+    </UndefinedThisPropertyFetch>
+  </file>
+  <file src="test/Middleware/RouteMiddlewareTest.php">
+    <MixedArgument occurrences="15">
+      <code>$this-&gt;handler-&gt;reveal()</code>
+      <code>$this-&gt;handler-&gt;reveal()</code>
+      <code>$this-&gt;handler-&gt;reveal()</code>
+      <code>$this-&gt;request-&gt;reveal()</code>
+      <code>$this-&gt;request-&gt;reveal()</code>
+      <code>$this-&gt;request-&gt;reveal()</code>
+      <code>$this-&gt;request-&gt;reveal()</code>
+      <code>$this-&gt;request-&gt;reveal()</code>
+      <code>$this-&gt;request-&gt;reveal()</code>
+      <code>$this-&gt;request-&gt;reveal()</code>
+      <code>$this-&gt;request-&gt;reveal()</code>
+      <code>$this-&gt;request-&gt;reveal()</code>
+      <code>$this-&gt;response-&gt;reveal()</code>
+      <code>$this-&gt;response-&gt;reveal()</code>
+      <code>$this-&gt;response-&gt;reveal()</code>
+    </MixedArgument>
+    <PossiblyUndefinedMethod occurrences="28">
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>will</code>
+      <code>will</code>
+      <code>will</code>
+      <code>will</code>
+      <code>will</code>
+      <code>will</code>
+      <code>will</code>
+      <code>will</code>
+      <code>will</code>
+      <code>will</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+    </PossiblyUndefinedMethod>
+    <UndefinedMethod occurrences="10">
+      <code>[$this-&gt;request, 'reveal']</code>
+      <code>[$this-&gt;request, 'reveal']</code>
+      <code>[$this-&gt;request, 'reveal']</code>
+      <code>[$this-&gt;request, 'reveal']</code>
+      <code>[$this-&gt;request, 'reveal']</code>
+      <code>[$this-&gt;request, 'reveal']</code>
+      <code>[$this-&gt;request, 'reveal']</code>
+      <code>[$this-&gt;response, 'reveal']</code>
+      <code>[$this-&gt;response, 'reveal']</code>
+      <code>[$this-&gt;response, 'reveal']</code>
+    </UndefinedMethod>
+  </file>
+  <file src="test/RouteCollectorFactoryTest.php">
+    <MixedArgument occurrences="3">
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+    </MixedArgument>
+    <MixedMethodCall occurrences="3">
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+    </MixedMethodCall>
+    <PossiblyInvalidMethodCall occurrences="6">
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+    </PossiblyInvalidMethodCall>
+    <PossiblyUndefinedMethod occurrences="3">
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+    </PossiblyUndefinedMethod>
+  </file>
+  <file src="test/RouteCollectorTest.php">
+    <InvalidArgument occurrences="11">
+      <code>Argument::type(Route::class)</code>
+      <code>Argument::type(Route::class)</code>
+      <code>Argument::type(Route::class)</code>
+      <code>Argument::type(Route::class)</code>
+      <code>Argument::type(Route::class)</code>
+      <code>Argument::type(Route::class)</code>
+      <code>Argument::type(Route::class)</code>
+      <code>Argument::type(Route::class)</code>
+      <code>Argument::type(Route::class)</code>
+      <code>Argument::type(Route::class)</code>
+      <code>Argument::type(Route::class)</code>
+    </InvalidArgument>
+    <MixedArgument occurrences="4">
+      <code>$path</code>
+      <code>$this-&gt;response-&gt;reveal()</code>
+      <code>$this-&gt;router-&gt;reveal()</code>
+      <code>$this-&gt;router-&gt;reveal()</code>
+    </MixedArgument>
+    <MixedInferredReturnType occurrences="1">
+      <code>mixed[]</code>
+    </MixedInferredReturnType>
+    <PossiblyNullReference occurrences="11">
+      <code>shouldBeCalled</code>
+      <code>shouldBeCalled</code>
+      <code>shouldBeCalled</code>
+      <code>shouldBeCalled</code>
+      <code>shouldBeCalledTimes</code>
+      <code>shouldBeCalledTimes</code>
+      <code>shouldBeCalledTimes</code>
+      <code>shouldBeCalledTimes</code>
+      <code>shouldBeCalledTimes</code>
+      <code>shouldBeCalledTimes</code>
+      <code>shouldBeCalledTimes</code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedMethod occurrences="3">
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+    </PossiblyUndefinedMethod>
+    <RedundantCondition occurrences="1">
+      <code>assertIsArray</code>
+    </RedundantCondition>
+  </file>
+  <file src="test/RouteResultTest.php">
+    <MixedAssignment occurrences="2">
+      <code>$result</code>
+      <code>$route</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="6">
+      <code>getAllowedMethods</code>
+      <code>getAllowedMethods</code>
+      <code>getMatchedRouteName</code>
+      <code>getName</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+    </MixedMethodCall>
+  </file>
+  <file src="test/RouteTest.php">
+    <InvalidArgument occurrences="22">
+      <code>$this-&gt;noopMiddleware</code>
+      <code>$this-&gt;noopMiddleware</code>
+      <code>$this-&gt;noopMiddleware</code>
+      <code>$this-&gt;noopMiddleware</code>
+      <code>$this-&gt;noopMiddleware</code>
+      <code>$this-&gt;noopMiddleware</code>
+      <code>$this-&gt;noopMiddleware</code>
+      <code>$this-&gt;noopMiddleware</code>
+      <code>$this-&gt;noopMiddleware</code>
+      <code>$this-&gt;noopMiddleware</code>
+      <code>$this-&gt;noopMiddleware</code>
+      <code>$this-&gt;noopMiddleware</code>
+      <code>$this-&gt;noopMiddleware</code>
+      <code>$this-&gt;noopMiddleware</code>
+      <code>$this-&gt;noopMiddleware</code>
+      <code>$this-&gt;noopMiddleware</code>
+      <code>$this-&gt;noopMiddleware</code>
+      <code>$this-&gt;noopMiddleware</code>
+      <code>'FOO'</code>
+      <code>12345</code>
+      <code>12345</code>
+      <code>12345</code>
+    </InvalidArgument>
+    <InvalidPropertyAssignmentValue occurrences="1">
+      <code>$this-&gt;prophesize(MiddlewareInterface::class)-&gt;reveal()</code>
+    </InvalidPropertyAssignmentValue>
+    <MixedArgument occurrences="1">
+      <code>$middleware</code>
+    </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>$invalidHttpMethods</code>
+    </MixedArgumentTypeCoercion>
+    <MixedInferredReturnType occurrences="1">
+      <code>mixed[]</code>
+    </MixedInferredReturnType>
+    <PossiblyInvalidArgument occurrences="1">
+      <code>testThrowsExceptionIfInvalidHttpMethodsAreProvided</code>
+    </PossiblyInvalidArgument>
+  </file>
+</files>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -4,6 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    errorBaseline="psalm-baseline.xml"
 >
     <projectFiles>
         <directory name="src"/>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<psalm
+    totallyTyped="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+>
+    <projectFiles>
+        <directory name="src"/>
+        <directory name="test"/>
+        <ignoreFiles>
+            <directory name="vendor"/>
+        </ignoreFiles>
+    </projectFiles>
+
+    <issueHandlers>
+        <InternalMethod>
+            <errorLevel type="suppress">
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::method"/>
+            </errorLevel>
+            <errorLevel type="suppress">
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::willReturn"/>
+            </errorLevel>
+            <errorLevel type="suppress">
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::with"/>
+            </errorLevel>
+        </InternalMethod>
+    </issueHandlers>
+    <plugins>
+        <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
+    </plugins>
+</psalm>

--- a/src/Test/AbstractImplicitMethodsIntegrationTest.php
+++ b/src/Test/AbstractImplicitMethodsIntegrationTest.php
@@ -119,8 +119,6 @@ abstract class AbstractImplicitMethodsIntegrationTest extends TestCase
 
     /**
      * @dataProvider method
-     *
-     * @return void
      */
     public function testExplicitRequest(string $method, array $routes): void
     {
@@ -202,8 +200,6 @@ abstract class AbstractImplicitMethodsIntegrationTest extends TestCase
      * returned response should be 405: Method Not Allowed - handled by MethodNotAllowedMiddleware.
      *
      * @dataProvider withoutImplicitMiddleware
-     *
-     * @return void
      */
     public function testWithoutImplicitMiddleware(string $requestMethod, array $allowedMethods): void
     {
@@ -252,8 +248,6 @@ abstract class AbstractImplicitMethodsIntegrationTest extends TestCase
 
     /**
      * @dataProvider implicitRoutesAndRequests
-     *
-     * @return void
      */
     public function testImplicitHeadRequest(
         string $routePath,
@@ -334,8 +328,6 @@ abstract class AbstractImplicitMethodsIntegrationTest extends TestCase
 
     /**
      * @dataProvider implicitRoutesAndRequests
-     *
-     * @return void
      */
     public function testImplicitOptionsRequest(
         string $routePath,

--- a/src/Test/AbstractImplicitMethodsIntegrationTest.php
+++ b/src/Test/AbstractImplicitMethodsIntegrationTest.php
@@ -119,8 +119,10 @@ abstract class AbstractImplicitMethodsIntegrationTest extends TestCase
 
     /**
      * @dataProvider method
+     *
+     * @return void
      */
-    public function testExplicitRequest(string $method, array $routes)
+    public function testExplicitRequest(string $method, array $routes): void
     {
         $implicitRoute = null;
         $router        = $this->getRouter();
@@ -200,8 +202,10 @@ abstract class AbstractImplicitMethodsIntegrationTest extends TestCase
      * returned response should be 405: Method Not Allowed - handled by MethodNotAllowedMiddleware.
      *
      * @dataProvider withoutImplicitMiddleware
+     *
+     * @return void
      */
-    public function testWithoutImplicitMiddleware(string $requestMethod, array $allowedMethods)
+    public function testWithoutImplicitMiddleware(string $requestMethod, array $allowedMethods): void
     {
         $router = $this->getRouter();
         foreach ($allowedMethods as $routeMethod) {
@@ -248,13 +252,15 @@ abstract class AbstractImplicitMethodsIntegrationTest extends TestCase
 
     /**
      * @dataProvider implicitRoutesAndRequests
+     *
+     * @return void
      */
     public function testImplicitHeadRequest(
         string $routePath,
         array $routeOptions,
         string $requestPath,
         array $expectedParams
-    ) {
+    ): void {
         $finalResponse = (new Response())->withHeader('foo-bar', 'baz');
         $finalResponse->getBody()->write('FOO BAR BODY');
 
@@ -328,12 +334,14 @@ abstract class AbstractImplicitMethodsIntegrationTest extends TestCase
 
     /**
      * @dataProvider implicitRoutesAndRequests
+     *
+     * @return void
      */
     public function testImplicitOptionsRequest(
         string $routePath,
         array $routeOptions,
         string $requestPath
-    ) {
+    ): void {
         $middleware1 = $this->prophesize(MiddlewareInterface::class)->reveal();
         $middleware2 = $this->prophesize(MiddlewareInterface::class)->reveal();
         $route1      = new Route($routePath, $middleware1, [RequestMethod::METHOD_GET]);
@@ -368,7 +376,7 @@ abstract class AbstractImplicitMethodsIntegrationTest extends TestCase
         $this->assertSame($finalResponse->reveal(), $response);
     }
 
-    public function testImplicitOptionsRequestRouteNotFound()
+    public function testImplicitOptionsRequestRouteNotFound(): void
     {
         $router = $this->getRouter();
 

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
 
 class ConfigProviderTest extends TestCase
 {
-    public function testProviderProvidesFactoriesForAllMiddleware()
+    public function testProviderProvidesFactoriesForAllMiddleware(): void
     {
         $provider = new ConfigProvider();
         $config   = $provider();

--- a/test/Middleware/DispatchMiddlewareFactoryTest.php
+++ b/test/Middleware/DispatchMiddlewareFactoryTest.php
@@ -13,10 +13,13 @@ namespace MezzioTest\Router\Middleware;
 use Mezzio\Router\Middleware\DispatchMiddleware;
 use Mezzio\Router\Middleware\DispatchMiddlewareFactory;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Container\ContainerInterface;
 
 class DispatchMiddlewareFactoryTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testFactoryProducesDispatchMiddleware(): void
     {
         $container  = $this->prophesize(ContainerInterface::class)->reveal();

--- a/test/Middleware/DispatchMiddlewareFactoryTest.php
+++ b/test/Middleware/DispatchMiddlewareFactoryTest.php
@@ -17,7 +17,7 @@ use Psr\Container\ContainerInterface;
 
 class DispatchMiddlewareFactoryTest extends TestCase
 {
-    public function testFactoryProducesDispatchMiddleware()
+    public function testFactoryProducesDispatchMiddleware(): void
     {
         $container  = $this->prophesize(ContainerInterface::class)->reveal();
         $factory    = new DispatchMiddlewareFactory();

--- a/test/Middleware/DispatchMiddlewareTest.php
+++ b/test/Middleware/DispatchMiddlewareTest.php
@@ -41,7 +41,7 @@ class DispatchMiddlewareTest extends TestCase
         $this->middleware = new DispatchMiddleware();
     }
 
-    public function testInvokesHandlerIfRequestDoesNotContainRouteResult()
+    public function testInvokesHandlerIfRequestDoesNotContainRouteResult(): void
     {
         $this->request->getAttribute(RouteResult::class, false)->willReturn(false);
         $this->handler->handle($this->request->reveal())->willReturn($this->response);
@@ -51,7 +51,7 @@ class DispatchMiddlewareTest extends TestCase
         $this->assertSame($this->response, $response);
     }
 
-    public function testInvokesRouteResultWhenPresent()
+    public function testInvokesRouteResultWhenPresent(): void
     {
         $this->handler->handle(Argument::any())->shouldNotBeCalled();
 

--- a/test/Middleware/DispatchMiddlewareTest.php
+++ b/test/Middleware/DispatchMiddlewareTest.php
@@ -14,6 +14,7 @@ use Mezzio\Router\Middleware\DispatchMiddleware;
 use Mezzio\Router\RouteResult;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -21,6 +22,8 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 class DispatchMiddlewareTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @var RequestHandlerInterface|ObjectProphecy */
     private $handler;
 

--- a/test/Middleware/ImplicitHeadMiddlewareFactoryTest.php
+++ b/test/Middleware/ImplicitHeadMiddlewareFactoryTest.php
@@ -15,6 +15,7 @@ use Mezzio\Router\Middleware\ImplicitHeadMiddleware;
 use Mezzio\Router\Middleware\ImplicitHeadMiddlewareFactory;
 use Mezzio\Router\RouterInterface;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\StreamInterface;
@@ -22,6 +23,8 @@ use Zend\Expressive\Router\RouterInterface as ZendExpressiveRouterInterface;
 
 class ImplicitHeadMiddlewareFactoryTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @var ContainerInterface|ObjectProphecy */
     private $container;
 

--- a/test/Middleware/ImplicitHeadMiddlewareFactoryTest.php
+++ b/test/Middleware/ImplicitHeadMiddlewareFactoryTest.php
@@ -34,7 +34,7 @@ class ImplicitHeadMiddlewareFactoryTest extends TestCase
         $this->factory   = new ImplicitHeadMiddlewareFactory();
     }
 
-    public function testFactoryRaisesExceptionIfRouterInterfaceServiceIsMissing()
+    public function testFactoryRaisesExceptionIfRouterInterfaceServiceIsMissing(): void
     {
         $this->container->has(RouterInterface::class)->willReturn(false);
         $this->container->has(ZendExpressiveRouterInterface::class)->willReturn(false);
@@ -43,7 +43,7 @@ class ImplicitHeadMiddlewareFactoryTest extends TestCase
         ($this->factory)($this->container->reveal());
     }
 
-    public function testFactoryRaisesExceptionIfStreamFactoryServiceIsMissing()
+    public function testFactoryRaisesExceptionIfStreamFactoryServiceIsMissing(): void
     {
         $this->container->has(RouterInterface::class)->willReturn(true);
         $this->container->has(StreamInterface::class)->willReturn(false);
@@ -52,10 +52,10 @@ class ImplicitHeadMiddlewareFactoryTest extends TestCase
         ($this->factory)($this->container->reveal());
     }
 
-    public function testFactoryProducesImplicitHeadMiddlewareWhenAllDependenciesPresent()
+    public function testFactoryProducesImplicitHeadMiddlewareWhenAllDependenciesPresent(): void
     {
         $router        = $this->prophesize(RouterInterface::class);
-        $streamFactory = function () {
+        $streamFactory = function (): void {
         };
 
         $this->container->has(RouterInterface::class)->willReturn(true);

--- a/test/Middleware/ImplicitHeadMiddlewareTest.php
+++ b/test/Middleware/ImplicitHeadMiddlewareTest.php
@@ -17,6 +17,7 @@ use Mezzio\Router\RouteResult;
 use Mezzio\Router\RouterInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -26,6 +27,8 @@ use Zend\Expressive\Router\RouteResult as ZendExpressiveRouteResult;
 
 class ImplicitHeadMiddlewareTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @var ImplicitHeadMiddleware */
     private $middleware;
 

--- a/test/Middleware/ImplicitHeadMiddlewareTest.php
+++ b/test/Middleware/ImplicitHeadMiddlewareTest.php
@@ -51,7 +51,7 @@ class ImplicitHeadMiddlewareTest extends TestCase
         $this->response   = $this->prophesize(ResponseInterface::class);
     }
 
-    public function testReturnsResultOfHandlerOnNonHeadRequests()
+    public function testReturnsResultOfHandlerOnNonHeadRequests(): void
     {
         $request = $this->prophesize(ServerRequestInterface::class);
         $request->getMethod()->willReturn(RequestMethod::METHOD_GET);
@@ -64,7 +64,7 @@ class ImplicitHeadMiddlewareTest extends TestCase
         $this->assertSame($this->response->reveal(), $result);
     }
 
-    public function testReturnsResultOfHandlerWhenNoRouteResultPresentInRequest()
+    public function testReturnsResultOfHandlerWhenNoRouteResultPresentInRequest(): void
     {
         $request = $this->prophesize(ServerRequestInterface::class);
         $request->getMethod()->willReturn(RequestMethod::METHOD_HEAD);
@@ -78,7 +78,7 @@ class ImplicitHeadMiddlewareTest extends TestCase
         $this->assertSame($this->response->reveal(), $result);
     }
 
-    public function testReturnsResultOfHandlerWhenRouteSupportsHeadExplicitly()
+    public function testReturnsResultOfHandlerWhenRouteSupportsHeadExplicitly(): void
     {
         $route  = $this->prophesize(Route::class);
         $result = RouteResult::fromRoute($route->reveal());
@@ -95,7 +95,7 @@ class ImplicitHeadMiddlewareTest extends TestCase
         $this->assertSame($this->response->reveal(), $result);
     }
 
-    public function testReturnsResultOfHandlerWhenRouteDoesNotExplicitlySupportHeadAndDoesNotSupportGet()
+    public function testReturnsResultOfHandlerWhenRouteDoesNotExplicitlySupportHeadAndDoesNotSupportGet(): void
     {
         $result = RouteResult::fromRouteFailure([]);
 
@@ -114,7 +114,7 @@ class ImplicitHeadMiddlewareTest extends TestCase
         $this->assertSame($this->response->reveal(), $response);
     }
 
-    public function testInvokesHandlerWhenRouteImplicitlySupportsHeadAndSupportsGet()
+    public function testInvokesHandlerWhenRouteImplicitlySupportsHeadAndSupportsGet(): void
     {
         $result = RouteResult::fromRouteFailure([]);
 
@@ -150,7 +150,7 @@ class ImplicitHeadMiddlewareTest extends TestCase
         $this->assertSame($response->reveal(), $result);
     }
 
-    public function testInvokesHandlerWithRequestComposingRouteResultAndAttributes()
+    public function testInvokesHandlerWithRequestComposingRouteResultAndAttributes(): void
     {
         $result = RouteResult::fromRouteFailure([]);
 

--- a/test/Middleware/ImplicitOptionsMiddlewareFactoryTest.php
+++ b/test/Middleware/ImplicitOptionsMiddlewareFactoryTest.php
@@ -32,7 +32,7 @@ class ImplicitOptionsMiddlewareFactoryTest extends TestCase
         $this->factory   = new ImplicitOptionsMiddlewareFactory();
     }
 
-    public function testFactoryRaisesExceptionIfResponseFactoryServiceIsMissing()
+    public function testFactoryRaisesExceptionIfResponseFactoryServiceIsMissing(): void
     {
         $this->container->has(ResponseInterface::class)->willReturn(false);
 
@@ -40,9 +40,9 @@ class ImplicitOptionsMiddlewareFactoryTest extends TestCase
         ($this->factory)($this->container->reveal());
     }
 
-    public function testFactoryProducesImplicitOptionsMiddlewareWhenAllDependenciesPresent()
+    public function testFactoryProducesImplicitOptionsMiddlewareWhenAllDependenciesPresent(): void
     {
-        $factory = function () {
+        $factory = function (): void {
         };
 
         $this->container->has(ResponseInterface::class)->willReturn(true);

--- a/test/Middleware/ImplicitOptionsMiddlewareFactoryTest.php
+++ b/test/Middleware/ImplicitOptionsMiddlewareFactoryTest.php
@@ -14,12 +14,15 @@ use Mezzio\Router\Exception\MissingDependencyException;
 use Mezzio\Router\Middleware\ImplicitOptionsMiddleware;
 use Mezzio\Router\Middleware\ImplicitOptionsMiddlewareFactory;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 
 class ImplicitOptionsMiddlewareFactoryTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @var ContainerInterface|ObjectProphecy */
     private $container;
 

--- a/test/Middleware/ImplicitOptionsMiddlewareTest.php
+++ b/test/Middleware/ImplicitOptionsMiddlewareTest.php
@@ -15,6 +15,7 @@ use Mezzio\Router\Middleware\ImplicitOptionsMiddleware;
 use Mezzio\Router\Route;
 use Mezzio\Router\RouteResult;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -24,6 +25,8 @@ use function implode;
 
 class ImplicitOptionsMiddlewareTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @var ImplicitOptionsMiddleware */
     private $middleware;
 

--- a/test/Middleware/ImplicitOptionsMiddlewareTest.php
+++ b/test/Middleware/ImplicitOptionsMiddlewareTest.php
@@ -40,7 +40,7 @@ class ImplicitOptionsMiddlewareTest extends TestCase
         $this->middleware = new ImplicitOptionsMiddleware($responseFactory);
     }
 
-    public function testNonOptionsRequestInvokesHandler()
+    public function testNonOptionsRequestInvokesHandler(): void
     {
         $request = $this->prophesize(ServerRequestInterface::class);
         $request->getMethod()->willReturn(RequestMethod::METHOD_GET);
@@ -55,7 +55,7 @@ class ImplicitOptionsMiddlewareTest extends TestCase
         $this->assertSame($response, $result);
     }
 
-    public function testMissingRouteResultInvokesHandler()
+    public function testMissingRouteResultInvokesHandler(): void
     {
         $request = $this->prophesize(ServerRequestInterface::class);
         $request->getMethod()->willReturn(RequestMethod::METHOD_OPTIONS);
@@ -70,7 +70,7 @@ class ImplicitOptionsMiddlewareTest extends TestCase
         $this->assertSame($response, $result);
     }
 
-    public function testReturnsResultOfHandlerWhenRouteSupportsOptionsExplicitly()
+    public function testReturnsResultOfHandlerWhenRouteSupportsOptionsExplicitly(): void
     {
         $route = $this->prophesize(Route::class);
 
@@ -89,7 +89,7 @@ class ImplicitOptionsMiddlewareTest extends TestCase
         $this->assertSame($response, $result);
     }
 
-    public function testInjectsAllowHeaderInResponseProvidedToConstructorDuringOptionsRequest()
+    public function testInjectsAllowHeaderInResponseProvidedToConstructorDuringOptionsRequest(): void
     {
         $allowedMethods = [RequestMethod::METHOD_GET, RequestMethod::METHOD_POST];
 
@@ -110,7 +110,7 @@ class ImplicitOptionsMiddlewareTest extends TestCase
         $this->assertSame($this->response->reveal(), $result);
     }
 
-    public function testReturnsResultOfHandlerWhenRouteNotFound()
+    public function testReturnsResultOfHandlerWhenRouteNotFound(): void
     {
         $result = RouteResult::fromRouteFailure(Route::HTTP_METHOD_ANY);
 

--- a/test/Middleware/MethodNotAllowedMiddlewareFactoryTest.php
+++ b/test/Middleware/MethodNotAllowedMiddlewareFactoryTest.php
@@ -32,7 +32,7 @@ class MethodNotAllowedMiddlewareFactoryTest extends TestCase
         $this->factory   = new MethodNotAllowedMiddlewareFactory();
     }
 
-    public function testFactoryRaisesExceptionIfResponseFactoryServiceIsMissing()
+    public function testFactoryRaisesExceptionIfResponseFactoryServiceIsMissing(): void
     {
         $this->container->has(ResponseInterface::class)->willReturn(false);
 
@@ -40,9 +40,9 @@ class MethodNotAllowedMiddlewareFactoryTest extends TestCase
         ($this->factory)($this->container->reveal());
     }
 
-    public function testFactoryProducesMethodNotAllowedMiddlewareWhenAllDependenciesPresent()
+    public function testFactoryProducesMethodNotAllowedMiddlewareWhenAllDependenciesPresent(): void
     {
-        $factory = function () {
+        $factory = function (): void {
         };
 
         $this->container->has(ResponseInterface::class)->willReturn(true);

--- a/test/Middleware/MethodNotAllowedMiddlewareFactoryTest.php
+++ b/test/Middleware/MethodNotAllowedMiddlewareFactoryTest.php
@@ -14,12 +14,15 @@ use Mezzio\Router\Exception\MissingDependencyException;
 use Mezzio\Router\Middleware\MethodNotAllowedMiddleware;
 use Mezzio\Router\Middleware\MethodNotAllowedMiddlewareFactory;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 
 class MethodNotAllowedMiddlewareFactoryTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @var ContainerInterface|ObjectProphecy */
     private $container;
 

--- a/test/Middleware/MethodNotAllowedMiddlewareTest.php
+++ b/test/Middleware/MethodNotAllowedMiddlewareTest.php
@@ -47,7 +47,7 @@ class MethodNotAllowedMiddlewareTest extends TestCase
         $this->middleware = new MethodNotAllowedMiddleware($responseFactory);
     }
 
-    public function testDelegatesToHandlerIfNoRouteResultPresentInRequest()
+    public function testDelegatesToHandlerIfNoRouteResultPresentInRequest(): void
     {
         $this->request->getAttribute(RouteResult::class)->willReturn(null);
         $this->handler->handle(Argument::that([$this->request, 'reveal']))->will([$this->response, 'reveal']);
@@ -61,7 +61,7 @@ class MethodNotAllowedMiddlewareTest extends TestCase
         );
     }
 
-    public function testDelegatesToHandlerIfRouteResultNotAMethodFailure()
+    public function testDelegatesToHandlerIfRouteResultNotAMethodFailure(): void
     {
         $result = RouteResult::fromRouteFailure(Route::HTTP_METHOD_ANY);
 
@@ -77,7 +77,7 @@ class MethodNotAllowedMiddlewareTest extends TestCase
         );
     }
 
-    public function testReturns405ResponseWithAllowHeaderIfResultDueToMethodFailure()
+    public function testReturns405ResponseWithAllowHeaderIfResultDueToMethodFailure(): void
     {
         $result = RouteResult::fromRouteFailure(['GET', 'POST']);
 

--- a/test/Middleware/MethodNotAllowedMiddlewareTest.php
+++ b/test/Middleware/MethodNotAllowedMiddlewareTest.php
@@ -16,6 +16,7 @@ use Mezzio\Router\Route;
 use Mezzio\Router\RouteResult;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -23,6 +24,8 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 class MethodNotAllowedMiddlewareTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @var RequestHandlerInterface|ObjectProphecy */
     private $handler;
 

--- a/test/Middleware/RouteMiddlewareFactoryTest.php
+++ b/test/Middleware/RouteMiddlewareFactoryTest.php
@@ -34,7 +34,7 @@ class RouteMiddlewareFactoryTest extends TestCase
         $this->factory   = new RouteMiddlewareFactory();
     }
 
-    public function testFactoryRaisesExceptionIfRouterServiceIsMissing()
+    public function testFactoryRaisesExceptionIfRouterServiceIsMissing(): void
     {
         $this->container->has(RouterInterface::class)->willReturn(false);
         $this->container->has(ZendExpressiveRouterInterface::class)->willReturn(false);
@@ -43,7 +43,7 @@ class RouteMiddlewareFactoryTest extends TestCase
         ($this->factory)($this->container->reveal());
     }
 
-    public function testFactoryProducesRouteMiddlewareWhenAllDependenciesPresent()
+    public function testFactoryProducesRouteMiddlewareWhenAllDependenciesPresent(): void
     {
         $router = $this->prophesize(RouterInterface::class)->reveal();
         $this->container->has(RouterInterface::class)->willReturn(true);
@@ -54,7 +54,7 @@ class RouteMiddlewareFactoryTest extends TestCase
         $this->assertInstanceOf(RouteMiddleware::class, $middleware);
     }
 
-    public function testFactoryAllowsSpecifyingRouterServiceViaConstructor()
+    public function testFactoryAllowsSpecifyingRouterServiceViaConstructor(): void
     {
         $router = $this->prophesize(RouterInterface::class)->reveal();
         $this->container->has(Router::class)->willReturn(true);
@@ -72,7 +72,7 @@ class RouteMiddlewareFactoryTest extends TestCase
         $this->assertSame($router, $middlewareRouter);
     }
 
-    public function testFactoryIsSerializable()
+    public function testFactoryIsSerializable(): void
     {
         $factory = RouteMiddlewareFactory::__set_state([
             'routerServiceName' => Router::class,

--- a/test/Middleware/RouteMiddlewareFactoryTest.php
+++ b/test/Middleware/RouteMiddlewareFactoryTest.php
@@ -16,12 +16,15 @@ use Mezzio\Router\Middleware\RouteMiddleware;
 use Mezzio\Router\Middleware\RouteMiddlewareFactory;
 use Mezzio\Router\RouterInterface;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
 use Zend\Expressive\Router\RouterInterface as ZendExpressiveRouterInterface;
 
 class RouteMiddlewareFactoryTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @var ContainerInterface|ObjectProphecy */
     private $container;
 

--- a/test/Middleware/RouteMiddlewareTest.php
+++ b/test/Middleware/RouteMiddlewareTest.php
@@ -15,6 +15,7 @@ use Mezzio\Router\Route;
 use Mezzio\Router\RouteResult;
 use Mezzio\Router\RouterInterface;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -24,6 +25,8 @@ use Zend\Expressive\Router\RouteResult as ZendExpressiveRouteResult;
 
 class RouteMiddlewareTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @var RouterInterface|ObjectProphecy */
     private $router;
 

--- a/test/Middleware/RouteMiddlewareTest.php
+++ b/test/Middleware/RouteMiddlewareTest.php
@@ -49,7 +49,7 @@ class RouteMiddlewareTest extends TestCase
         $this->middleware = new RouteMiddleware($this->router->reveal());
     }
 
-    public function testRoutingFailureDueToHttpMethodCallsHandlerWithRequestComposingRouteResult()
+    public function testRoutingFailureDueToHttpMethodCallsHandlerWithRequestComposingRouteResult(): void
     {
         $result = RouteResult::fromRouteFailure(['GET', 'POST']);
 
@@ -65,7 +65,7 @@ class RouteMiddlewareTest extends TestCase
         $this->assertSame($this->response->reveal(), $response);
     }
 
-    public function testGeneralRoutingFailureInvokesHandlerWithRequestComposingRouteResult()
+    public function testGeneralRoutingFailureInvokesHandlerWithRequestComposingRouteResult(): void
     {
         $result = RouteResult::fromRouteFailure(null);
 
@@ -81,7 +81,7 @@ class RouteMiddlewareTest extends TestCase
         $this->assertSame($this->response->reveal(), $response);
     }
 
-    public function testRoutingSuccessInvokesHandlerWithRequestComposingRouteResultAndAttributes()
+    public function testRoutingSuccessInvokesHandlerWithRequestComposingRouteResultAndAttributes(): void
     {
         $middleware = $this->prophesize(MiddlewareInterface::class)->reveal();
         $parameters = ['foo' => 'bar', 'baz' => 'bat'];

--- a/test/RouteCollectorFactoryTest.php
+++ b/test/RouteCollectorFactoryTest.php
@@ -15,6 +15,7 @@ use Mezzio\Router\RouteCollector;
 use Mezzio\Router\RouteCollectorFactory;
 use Mezzio\Router\RouterInterface;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
 use ReflectionProperty;
@@ -22,6 +23,8 @@ use Zend\Expressive\Router\RouterInterface as ZendExpressiveRouterInterface;
 
 class RouteCollectorFactoryTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @var ContainerInterface|ObjectProphecy */
     private $container;
 

--- a/test/RouteCollectorFactoryTest.php
+++ b/test/RouteCollectorFactoryTest.php
@@ -34,7 +34,7 @@ class RouteCollectorFactoryTest extends TestCase
         $this->factory   = new RouteCollectorFactory();
     }
 
-    public function testFactoryRaisesExceptionIfRouterServiceIsMissing()
+    public function testFactoryRaisesExceptionIfRouterServiceIsMissing(): void
     {
         $this->container->has(RouterInterface::class)->willReturn(false);
         $this->container->has(ZendExpressiveRouterInterface::class)->willReturn(false);
@@ -44,7 +44,7 @@ class RouteCollectorFactoryTest extends TestCase
         ($this->factory)($this->container->reveal());
     }
 
-    public function testFactoryProducesRouteCollectorWhenAllDependenciesPresent()
+    public function testFactoryProducesRouteCollectorWhenAllDependenciesPresent(): void
     {
         $router = $this->prophesize(RouterInterface::class)->reveal();
         $this->container->has(RouterInterface::class)->willReturn(true);
@@ -61,7 +61,7 @@ class RouteCollectorFactoryTest extends TestCase
         $this->assertTrue($r->getValue($collector));
     }
 
-    public function testFactoryProducesRouteCollectorUsingDetectDuplicatesFlagFromConfig()
+    public function testFactoryProducesRouteCollectorUsingDetectDuplicatesFlagFromConfig(): void
     {
         $router = $this->prophesize(RouterInterface::class)->reveal();
         $this->container->has(RouterInterface::class)->willReturn(true);

--- a/test/RouteCollectorTest.php
+++ b/test/RouteCollectorTest.php
@@ -72,7 +72,9 @@ class RouteCollectorTest extends TestCase
     }
 
     /**
-     * @return string[]
+     * @return string[][]
+     *
+     * @psalm-return array{GET: array{0: string}, POST: array{0: string}, PUT: array{0: string}, PATCH: array{0: string}, DELETE: array{0: string}}
      */
     public function commonHttpMethods(): array
     {
@@ -85,7 +87,7 @@ class RouteCollectorTest extends TestCase
         ];
     }
 
-    public function testRouteMethodReturnsRouteInstance()
+    public function testRouteMethodReturnsRouteInstance(): void
     {
         $this->router->addRoute(Argument::type(Route::class))->shouldBeCalled();
         $route = $this->collector->route('/foo', $this->noopMiddleware);
@@ -94,7 +96,7 @@ class RouteCollectorTest extends TestCase
         $this->assertSame($this->noopMiddleware, $route->getMiddleware());
     }
 
-    public function testAnyRouteMethod()
+    public function testAnyRouteMethod(): void
     {
         $this->router->addRoute(Argument::type(Route::class))->shouldBeCalled();
         $route = $this->collector->any('/foo', $this->noopMiddleware);
@@ -106,9 +108,12 @@ class RouteCollectorTest extends TestCase
 
     /**
      * @dataProvider commonHttpMethods
+     *
      * @param string $method
+     *
+     * @return void
      */
-    public function testCanCallRouteWithHttpMethods($method)
+    public function testCanCallRouteWithHttpMethods($method): void
     {
         $this->router->addRoute(Argument::type(Route::class))->shouldBeCalled();
         $route = $this->collector->route('/foo', $this->noopMiddleware, [$method]);
@@ -119,7 +124,7 @@ class RouteCollectorTest extends TestCase
         $this->assertSame([$method], $route->getAllowedMethods());
     }
 
-    public function testCanCallRouteWithMultipleHttpMethods()
+    public function testCanCallRouteWithMultipleHttpMethods(): void
     {
         $this->router->addRoute(Argument::type(Route::class))->shouldBeCalled();
         $methods = array_keys($this->commonHttpMethods());
@@ -130,7 +135,7 @@ class RouteCollectorTest extends TestCase
         $this->assertSame($methods, $route->getAllowedMethods());
     }
 
-    public function testCallingRouteWithExistingPathAndOmittingMethodsArgumentRaisesException()
+    public function testCallingRouteWithExistingPathAndOmittingMethodsArgumentRaisesException(): void
     {
         $this->router->addRoute(Argument::type(Route::class))->shouldBeCalledTimes(2);
         $this->collector->route('/foo', $this->noopMiddleware);
@@ -159,9 +164,12 @@ class RouteCollectorTest extends TestCase
 
     /**
      * @dataProvider invalidPathTypes
+     *
      * @param mixed $path
+     *
+     * @return void
      */
-    public function testCallingRouteWithAnInvalidPathTypeRaisesAnException($path)
+    public function testCallingRouteWithAnInvalidPathTypeRaisesAnException($path): void
     {
         $this->expectException(TypeError::class);
         $this->collector->route($path, $this->createNoopMiddleware());
@@ -169,9 +177,12 @@ class RouteCollectorTest extends TestCase
 
     /**
      * @dataProvider commonHttpMethods
+     *
      * @param mixed $method
+     *
+     * @return void
      */
-    public function testCommonHttpMethodsAreExposedAsClassMethodsAndReturnRoutes($method)
+    public function testCommonHttpMethodsAreExposedAsClassMethodsAndReturnRoutes($method): void
     {
         $route = $this->collector->{$method}('/foo', $this->noopMiddleware);
         $this->assertInstanceOf(Route::class, $route);
@@ -180,7 +191,7 @@ class RouteCollectorTest extends TestCase
         $this->assertEquals([$method], $route->getAllowedMethods());
     }
 
-    public function testCreatingHttpRouteMethodWithExistingPathButDifferentMethodCreatesNewRouteInstance()
+    public function testCreatingHttpRouteMethodWithExistingPathButDifferentMethodCreatesNewRouteInstance(): void
     {
         $this->router->addRoute(Argument::type(Route::class))->shouldBeCalledTimes(2);
         $route = $this->collector->route('/foo', $this->noopMiddleware, [RequestMethod::METHOD_POST]);
@@ -193,7 +204,7 @@ class RouteCollectorTest extends TestCase
         $this->assertSame($middleware, $test->getMiddleware());
     }
 
-    public function testGetRoutes()
+    public function testGetRoutes(): void
     {
         $middleware1 = $this->prophesize(MiddlewareInterface::class)->reveal();
         $this->collector->any('/foo', $middleware1, 'abc');
@@ -217,7 +228,7 @@ class RouteCollectorTest extends TestCase
         $this->assertSame([RequestMethod::METHOD_GET], $routes[1]->getAllowedMethods());
     }
 
-    public function testCreatingHttpRouteWithExistingPathShouldBeLinear()
+    public function testCreatingHttpRouteWithExistingPathShouldBeLinear(): void
     {
         $start = microtime(true);
         foreach (range(1, 10) as $item) {
@@ -246,7 +257,7 @@ class RouteCollectorTest extends TestCase
         );
     }
 
-    public function testCreatingHttpRouteWithExistingPathAndMethodRaisesException()
+    public function testCreatingHttpRouteWithExistingPathAndMethodRaisesException(): void
     {
         $this->router->addRoute(Argument::type(Route::class))->shouldBeCalledTimes(1);
         $this->collector->get('/foo', $this->noopMiddleware, 'route1');
@@ -258,7 +269,7 @@ class RouteCollectorTest extends TestCase
         $this->collector->get('/foo', $this->createNoopMiddleware(), 'route2');
     }
 
-    public function testCheckDuplicateRouteWhenExistsRouteForAnyMethods()
+    public function testCheckDuplicateRouteWhenExistsRouteForAnyMethods(): void
     {
         $this->router->addRoute(Argument::type(Route::class))->shouldBeCalledTimes(1);
         $this->collector->any('/foo', $this->noopMiddleware, 'route1');
@@ -270,7 +281,7 @@ class RouteCollectorTest extends TestCase
         $this->collector->get('/foo', $this->createNoopMiddleware(), 'route2');
     }
 
-    public function testCheckDuplicateRouteWhenExistsRouteForGetMethodsAndAddingRouteForAnyMethod()
+    public function testCheckDuplicateRouteWhenExistsRouteForGetMethodsAndAddingRouteForAnyMethod(): void
     {
         $this->router->addRoute(Argument::type(Route::class))->shouldBeCalledTimes(1);
         $this->collector->get('/foo', $this->noopMiddleware, 'route1');
@@ -282,7 +293,7 @@ class RouteCollectorTest extends TestCase
         $this->collector->any('/foo', $this->createNoopMiddleware(), 'route2');
     }
 
-    public function testCreatingHttpRouteWithExistingNameRaisesException()
+    public function testCreatingHttpRouteWithExistingNameRaisesException(): void
     {
         $this->router->addRoute(Argument::type(Route::class))->shouldBeCalledTimes(1);
         $this->collector->get('/foo', $this->noopMiddleware, 'duplicate');
@@ -294,7 +305,7 @@ class RouteCollectorTest extends TestCase
         $this->collector->get('/foo/baz', $this->createNoopMiddleware(), 'duplicate');
     }
 
-    public function testCreatingHttpRouteWithExistingNameDoesNotRaiseExceptionIfDuplicateDetectionDisabled()
+    public function testCreatingHttpRouteWithExistingNameDoesNotRaiseExceptionIfDuplicateDetectionDisabled(): void
     {
         $this->router->addRoute(Argument::type(Route::class))->shouldBeCalledTimes(2);
         $collector = new RouteCollector($this->router->reveal(), false);

--- a/test/RouteCollectorTest.php
+++ b/test/RouteCollectorTest.php
@@ -17,6 +17,7 @@ use Mezzio\Router\RouteCollector;
 use Mezzio\Router\RouterInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -31,6 +32,8 @@ use function sprintf;
 
 class RouteCollectorTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @var RouterInterface|ObjectProphecy */
     private $router;
 
@@ -73,8 +76,7 @@ class RouteCollectorTest extends TestCase
 
     /**
      * @return string[][]
-     *
-     * @psalm-return array{GET: array{0: string}, POST: array{0: string}, PUT: array{0: string}, PATCH: array{0: string}, DELETE: array{0: string}}
+     * @psalm-return array<array-key, array{0:string}>
      */
     public function commonHttpMethods(): array
     {
@@ -108,10 +110,7 @@ class RouteCollectorTest extends TestCase
 
     /**
      * @dataProvider commonHttpMethods
-     *
      * @param string $method
-     *
-     * @return void
      */
     public function testCanCallRouteWithHttpMethods($method): void
     {
@@ -164,10 +163,7 @@ class RouteCollectorTest extends TestCase
 
     /**
      * @dataProvider invalidPathTypes
-     *
      * @param mixed $path
-     *
-     * @return void
      */
     public function testCallingRouteWithAnInvalidPathTypeRaisesAnException($path): void
     {
@@ -177,10 +173,7 @@ class RouteCollectorTest extends TestCase
 
     /**
      * @dataProvider commonHttpMethods
-     *
      * @param mixed $method
-     *
-     * @return void
      */
     public function testCommonHttpMethodsAreExposedAsClassMethodsAndReturnRoutes($method): void
     {

--- a/test/RouteResultTest.php
+++ b/test/RouteResultTest.php
@@ -13,6 +13,8 @@ namespace MezzioTest\Router;
 use Mezzio\Router\Route;
 use Mezzio\Router\RouteResult;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -22,6 +24,8 @@ use Psr\Http\Server\RequestHandlerInterface;
  */
 class RouteResultTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testRouteNameIsNotRetrievable(): void
     {
         $result = RouteResult::fromRouteFailure([]);
@@ -65,9 +69,8 @@ class RouteResultTest extends TestCase
     }
 
     /**
-     * @return (RouteResult|\Prophecy\Prophecy\ObjectProphecy)[]
-     *
-     * @psalm-return array{route: \Prophecy\Prophecy\ObjectProphecy<Route>, result: RouteResult}
+     * @return (RouteResult|ObjectProphecy)[]
+     * @psalm-return array{route: ObjectProphecy<Route>, result: RouteResult}
      */
     public function testFromRouteShouldComposeRouteInResult(): array
     {
@@ -83,8 +86,6 @@ class RouteResultTest extends TestCase
 
     /**
      * @depends testFromRouteShouldComposeRouteInResult
-     *
-     * @return void
      */
     public function testAllAccessorsShouldReturnExpectedDataWhenResultCreatedViaFromRoute(array $data): void
     {
@@ -114,8 +115,6 @@ class RouteResultTest extends TestCase
 
     /**
      * @depends testFailureResultDoesNotIndicateAMethodFailureIfAllMethodsAreAllowed
-     *
-     * @return void
      */
     public function testAllowedMethodsIncludesASingleWildcardEntryWhenAllMethodsAllowedForFailureResult(
         RouteResult $result

--- a/test/RouteResultTest.php
+++ b/test/RouteResultTest.php
@@ -22,25 +22,25 @@ use Psr\Http\Server\RequestHandlerInterface;
  */
 class RouteResultTest extends TestCase
 {
-    public function testRouteNameIsNotRetrievable()
+    public function testRouteNameIsNotRetrievable(): void
     {
         $result = RouteResult::fromRouteFailure([]);
         $this->assertFalse($result->getMatchedRouteName());
     }
 
-    public function testRouteFailureRetrieveAllHttpMethods()
+    public function testRouteFailureRetrieveAllHttpMethods(): void
     {
         $result = RouteResult::fromRouteFailure(Route::HTTP_METHOD_ANY);
         $this->assertSame(Route::HTTP_METHOD_ANY, $result->getAllowedMethods());
     }
 
-    public function testRouteFailureRetrieveHttpMethods()
+    public function testRouteFailureRetrieveHttpMethods(): void
     {
         $result = RouteResult::fromRouteFailure([]);
         $this->assertSame([], $result->getAllowedMethods());
     }
 
-    public function testRouteMatchedParams()
+    public function testRouteMatchedParams(): void
     {
         $params = ['foo' => 'bar'];
         $route  = $this->prophesize(Route::class);
@@ -49,13 +49,13 @@ class RouteResultTest extends TestCase
         $this->assertSame($params, $result->getMatchedParams());
     }
 
-    public function testRouteMethodFailure()
+    public function testRouteMethodFailure(): void
     {
         $result = RouteResult::fromRouteFailure(['GET']);
         $this->assertTrue($result->isMethodFailure());
     }
 
-    public function testRouteSuccessMethodFailure()
+    public function testRouteSuccessMethodFailure(): void
     {
         $params = ['foo' => 'bar'];
         $route  = $this->prophesize(Route::class);
@@ -65,7 +65,9 @@ class RouteResultTest extends TestCase
     }
 
     /**
-     * @return Route[]|RouteResult[]
+     * @return (RouteResult|\Prophecy\Prophecy\ObjectProphecy)[]
+     *
+     * @psalm-return array{route: \Prophecy\Prophecy\ObjectProphecy<Route>, result: RouteResult}
      */
     public function testFromRouteShouldComposeRouteInResult(): array
     {
@@ -81,8 +83,10 @@ class RouteResultTest extends TestCase
 
     /**
      * @depends testFromRouteShouldComposeRouteInResult
+     *
+     * @return void
      */
-    public function testAllAccessorsShouldReturnExpectedDataWhenResultCreatedViaFromRoute(array $data)
+    public function testAllAccessorsShouldReturnExpectedDataWhenResultCreatedViaFromRoute(array $data): void
     {
         $result = $data['result'];
         $route  = $data['route'];
@@ -94,7 +98,7 @@ class RouteResultTest extends TestCase
         $this->assertEquals(['HEAD', 'OPTIONS', 'GET'], $result->getAllowedMethods());
     }
 
-    public function testRouteFailureWithNoAllowedHttpMethodsShouldReportTrueForIsMethodFailure()
+    public function testRouteFailureWithNoAllowedHttpMethodsShouldReportTrueForIsMethodFailure(): void
     {
         $result = RouteResult::fromRouteFailure([]);
         $this->assertTrue($result->isMethodFailure());
@@ -110,14 +114,16 @@ class RouteResultTest extends TestCase
 
     /**
      * @depends testFailureResultDoesNotIndicateAMethodFailureIfAllMethodsAreAllowed
+     *
+     * @return void
      */
     public function testAllowedMethodsIncludesASingleWildcardEntryWhenAllMethodsAllowedForFailureResult(
         RouteResult $result
-    ) {
+    ): void {
         $this->assertSame(Route::HTTP_METHOD_ANY, $result->getAllowedMethods());
     }
 
-    public function testFailureResultProcessedAsMiddlewareDelegatesToHandler()
+    public function testFailureResultProcessedAsMiddlewareDelegatesToHandler(): void
     {
         $request  = $this->prophesize(ServerRequestInterface::class)->reveal();
         $response = $this->prophesize(ResponseInterface::class)->reveal();
@@ -129,7 +135,7 @@ class RouteResultTest extends TestCase
         $this->assertSame($response, $result->process($request, $handler->reveal()));
     }
 
-    public function testSuccessfulResultProcessedAsMiddlewareDelegatesToRoute()
+    public function testSuccessfulResultProcessedAsMiddlewareDelegatesToRoute(): void
     {
         $request  = $this->prophesize(ServerRequestInterface::class)->reveal();
         $response = $this->prophesize(ResponseInterface::class)->reveal();

--- a/test/RouteTest.php
+++ b/test/RouteTest.php
@@ -35,32 +35,32 @@ class RouteTest extends TestCase
         $this->noopMiddleware = $this->prophesize(MiddlewareInterface::class)->reveal();
     }
 
-    public function testRoutePathIsRetrievable()
+    public function testRoutePathIsRetrievable(): void
     {
         $route = new Route('/foo', $this->noopMiddleware);
         $this->assertEquals('/foo', $route->getPath());
     }
 
-    public function testRouteMiddlewareIsRetrievable()
+    public function testRouteMiddlewareIsRetrievable(): void
     {
         $route = new Route('/foo', $this->noopMiddleware);
         $this->assertSame($this->noopMiddleware, $route->getMiddleware());
     }
 
-    public function testRouteInstanceAcceptsAllHttpMethodsByDefault()
+    public function testRouteInstanceAcceptsAllHttpMethodsByDefault(): void
     {
         $route = new Route('/foo', $this->noopMiddleware);
         $this->assertSame(Route::HTTP_METHOD_ANY, $route->getAllowedMethods());
     }
 
-    public function testRouteAllowsSpecifyingHttpMethods()
+    public function testRouteAllowsSpecifyingHttpMethods(): void
     {
         $methods = [RequestMethod::METHOD_GET, RequestMethod::METHOD_POST];
         $route   = new Route('/foo', $this->noopMiddleware, $methods);
         $this->assertSame($methods, $route->getAllowedMethods());
     }
 
-    public function testRouteCanMatchMethod()
+    public function testRouteCanMatchMethod(): void
     {
         $methods = [RequestMethod::METHOD_GET, RequestMethod::METHOD_POST];
         $route   = new Route('/foo', $this->noopMiddleware, $methods);
@@ -70,19 +70,19 @@ class RouteTest extends TestCase
         $this->assertFalse($route->allowsMethod(RequestMethod::METHOD_DELETE));
     }
 
-    public function testRouteHeadMethodIsNotAllowedByDefault()
+    public function testRouteHeadMethodIsNotAllowedByDefault(): void
     {
         $route = new Route('/foo', $this->noopMiddleware, [RequestMethod::METHOD_GET]);
         $this->assertFalse($route->allowsMethod(RequestMethod::METHOD_HEAD));
     }
 
-    public function testRouteOptionsMethodIsNotAllowedByDefault()
+    public function testRouteOptionsMethodIsNotAllowedByDefault(): void
     {
         $route = new Route('/foo', $this->noopMiddleware, [RequestMethod::METHOD_GET]);
         $this->assertFalse($route->allowsMethod(RequestMethod::METHOD_OPTIONS));
     }
 
-    public function testRouteAllowsSpecifyingOptions()
+    public function testRouteAllowsSpecifyingOptions(): void
     {
         $options = ['foo' => 'bar'];
         $route   = new Route('/foo', $this->noopMiddleware);
@@ -90,31 +90,31 @@ class RouteTest extends TestCase
         $this->assertSame($options, $route->getOptions());
     }
 
-    public function testRouteOptionsAreEmptyByDefault()
+    public function testRouteOptionsAreEmptyByDefault(): void
     {
         $route = new Route('/foo', $this->noopMiddleware);
         $this->assertSame([], $route->getOptions());
     }
 
-    public function testRouteNameForRouteAcceptingAnyMethodMatchesPathByDefault()
+    public function testRouteNameForRouteAcceptingAnyMethodMatchesPathByDefault(): void
     {
         $route = new Route('/test', $this->noopMiddleware);
         $this->assertSame('/test', $route->getName());
     }
 
-    public function testRouteNameWithConstructor()
+    public function testRouteNameWithConstructor(): void
     {
         $route = new Route('/test', $this->noopMiddleware, [RequestMethod::METHOD_GET], 'test');
         $this->assertSame('test', $route->getName());
     }
 
-    public function testRouteNameWithGET()
+    public function testRouteNameWithGET(): void
     {
         $route = new Route('/test', $this->noopMiddleware, [RequestMethod::METHOD_GET]);
         $this->assertSame('/test^GET', $route->getName());
     }
 
-    public function testRouteNameWithGetAndPost()
+    public function testRouteNameWithGetAndPost(): void
     {
         $route = new Route('/test', $this->noopMiddleware, [RequestMethod::METHOD_GET, RequestMethod::METHOD_POST]);
         $this->assertSame('/test^GET' . Route::HTTP_METHOD_SEPARATOR . RequestMethod::METHOD_POST, $route->getName());
@@ -122,8 +122,10 @@ class RouteTest extends TestCase
 
     /**
      * @requires PHP < 7.3
+     *
+     * @return void
      */
-    public function testThrowsExceptionDuringConstructionIfPathIsNotStringPhpPriorTo73()
+    public function testThrowsExceptionDuringConstructionIfPathIsNotStringPhpPriorTo73(): void
     {
         $this->expectException(TypeError::class);
         $this->expectExceptionMessage('must be of the type string, integer given');
@@ -134,8 +136,10 @@ class RouteTest extends TestCase
     /**
      * @requires PHP 7.3
      * @requires PHP < 8.0
+     *
+     * @return void
      */
-    public function testThrowsExceptionDuringConstructionIfPathIsNotString()
+    public function testThrowsExceptionDuringConstructionIfPathIsNotString(): void
     {
         $this->expectException(TypeError::class);
         $this->expectExceptionMessage('must be of the type string, int given');
@@ -145,8 +149,10 @@ class RouteTest extends TestCase
 
     /**
      * @requires PHP < 8.0
+     *
+     * @return void
      */
-    public function testThrowsExceptionDuringConstructionOnInvalidMiddleware()
+    public function testThrowsExceptionDuringConstructionOnInvalidMiddleware(): void
     {
         $this->expectException(TypeError::class);
         $this->expectExceptionMessage(sprintf(
@@ -159,8 +165,10 @@ class RouteTest extends TestCase
 
     /**
      * @requires PHP < 8.0
+     *
+     * @return void
      */
-    public function testThrowsExceptionDuringConstructionOnInvalidHttpMethod()
+    public function testThrowsExceptionDuringConstructionOnInvalidHttpMethod(): void
     {
         $this->expectException(TypeError::class);
         $this->expectExceptionMessage('must be of the type array or null, string given');
@@ -168,7 +176,7 @@ class RouteTest extends TestCase
         new Route('/foo', $this->noopMiddleware, 'FOO');
     }
 
-    public function testRouteNameIsMutable()
+    public function testRouteNameIsMutable(): void
     {
         $route = new Route('/foo', $this->noopMiddleware, [RequestMethod::METHOD_GET], 'foo');
         $route->setName('bar');
@@ -191,8 +199,10 @@ class RouteTest extends TestCase
 
     /**
      * @dataProvider invalidHttpMethodsProvider
+     *
+     * @return void
      */
-    public function testThrowsExceptionIfInvalidHttpMethodsAreProvided(array $invalidHttpMethods)
+    public function testThrowsExceptionIfInvalidHttpMethodsAreProvided(array $invalidHttpMethods): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('One or more HTTP methods were invalid');
@@ -200,7 +210,7 @@ class RouteTest extends TestCase
         new Route('/test', $this->noopMiddleware, $invalidHttpMethods);
     }
 
-    public function testAllowsHttpInteropMiddleware()
+    public function testAllowsHttpInteropMiddleware(): void
     {
         $middleware = $this->prophesize(MiddlewareInterface::class)->reveal();
         $route      = new Route('/test', $middleware, Route::HTTP_METHOD_ANY);
@@ -231,10 +241,14 @@ class RouteTest extends TestCase
 
     /**
      * @requires PHP < 8.0
+     *
      * @dataProvider invalidMiddleware
+     *
      * @param mixed $middleware
+     *
+     * @return void
      */
-    public function testConstructorRaisesExceptionForInvalidMiddleware($middleware)
+    public function testConstructorRaisesExceptionForInvalidMiddleware($middleware): void
     {
         $this->expectException(TypeError::class);
         $this->expectExceptionMessage(sprintf(
@@ -245,7 +259,7 @@ class RouteTest extends TestCase
         new Route('/test', $middleware);
     }
 
-    public function testRouteIsMiddlewareAndProxiesToComposedMiddleware()
+    public function testRouteIsMiddlewareAndProxiesToComposedMiddleware(): void
     {
         $request    = $this->prophesize(ServerRequestInterface::class)->reveal();
         $handler    = $this->prophesize(RequestHandlerInterface::class)->reveal();
@@ -257,7 +271,7 @@ class RouteTest extends TestCase
         $this->assertSame($response, $route->process($request, $handler));
     }
 
-    public function testConstructorShouldRaiseExceptionIfMethodsArgumentIsAnEmptyArray()
+    public function testConstructorShouldRaiseExceptionIfMethodsArgumentIsAnEmptyArray(): void
     {
         $middleware = $this->prophesize(MiddlewareInterface::class)->reveal();
 

--- a/test/RouteTest.php
+++ b/test/RouteTest.php
@@ -14,6 +14,7 @@ use Fig\Http\Message\RequestMethodInterface as RequestMethod;
 use Mezzio\Router\Exception\InvalidArgumentException;
 use Mezzio\Router\Route;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
@@ -27,6 +28,8 @@ use function sprintf;
  */
 class RouteTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @var callable */
     private $noopMiddleware;
 
@@ -122,8 +125,6 @@ class RouteTest extends TestCase
 
     /**
      * @requires PHP < 7.3
-     *
-     * @return void
      */
     public function testThrowsExceptionDuringConstructionIfPathIsNotStringPhpPriorTo73(): void
     {
@@ -136,8 +137,6 @@ class RouteTest extends TestCase
     /**
      * @requires PHP 7.3
      * @requires PHP < 8.0
-     *
-     * @return void
      */
     public function testThrowsExceptionDuringConstructionIfPathIsNotString(): void
     {
@@ -149,8 +148,6 @@ class RouteTest extends TestCase
 
     /**
      * @requires PHP < 8.0
-     *
-     * @return void
      */
     public function testThrowsExceptionDuringConstructionOnInvalidMiddleware(): void
     {
@@ -165,8 +162,6 @@ class RouteTest extends TestCase
 
     /**
      * @requires PHP < 8.0
-     *
-     * @return void
      */
     public function testThrowsExceptionDuringConstructionOnInvalidHttpMethod(): void
     {
@@ -199,8 +194,6 @@ class RouteTest extends TestCase
 
     /**
      * @dataProvider invalidHttpMethodsProvider
-     *
-     * @return void
      */
     public function testThrowsExceptionIfInvalidHttpMethodsAreProvided(array $invalidHttpMethods): void
     {
@@ -241,12 +234,8 @@ class RouteTest extends TestCase
 
     /**
      * @requires PHP < 8.0
-     *
      * @dataProvider invalidMiddleware
-     *
      * @param mixed $middleware
-     *
-     * @return void
      */
     public function testConstructorRaisesExceptionForInvalidMiddleware($middleware): void
     {


### PR DESCRIPTION
Adds Psalm integration to the package:

- Provides a `psalm.xml.dist` file.
- Adds vimeo/psalm and psalm/plugin-phpunit as development dependencies.
- Adds a "static-analysis" script to the Composer configuration.
- Adds integration to the Travis-CI workflow.
- Adds a baseline file, and fixes autocorrectible errors.

Fixes #7
