### PR TITLE
Add methods to the RouteCollector to retrieve registered routes by name

### DIFF
--- a/src/Exception/RouteCannotBeFoundException.php
+++ b/src/Exception/RouteCannotBeFoundException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mezzio\Router\Exception;
+
+use function sprintf;
+
+final class RouteCannotBeFoundException extends InvalidArgumentException
+{
+    public static function withName(string $name): self
+    {
+        return new self(sprintf(
+            'A route with the name "%s" has not been registered',
+            $name
+        ));
+    }
+}

--- a/src/RouteCollector.php
+++ b/src/RouteCollector.php
@@ -156,17 +156,6 @@ class RouteCollector implements RouteCollectorInterface
         return $this->detectDuplicates;
     }
 
-    public function routeExists(string $name): bool
-    {
-        try {
-            $this->retrieveRouteByName($name);
-
-            return true;
-        } catch (RouteCannotBeFoundException $error) {
-            return false;
-        }
-    }
-
     /**
      * Find the first route found that has the given name
      *

--- a/test/RouteCollectorTest.php
+++ b/test/RouteCollectorTest.php
@@ -355,18 +355,6 @@ class RouteCollectorTest extends TestCase
         self::assertNotSame($one, $two);
     }
 
-    public function testThatAKnownNamedRouteIsConsideredInExistence(): void
-    {
-        $this->router->expects(self::once())
-            ->method('addRoute')
-            ->willReturnArgument(0);
-
-        $this->collector->get('/foo', $this->noopMiddleware, 'something');
-
-        self::assertTrue($this->collector->routeExists('something'));
-        self::assertFalse($this->collector->routeExists('something-else'));
-    }
-
     public function testThatItIsExceptionalToRetrieveARouteByNameThatDoesNotExist(): void
     {
         $this->expectException(Exception\RouteCannotBeFoundException::class);

--- a/test/RouteCollectorTest.php
+++ b/test/RouteCollectorTest.php
@@ -387,4 +387,16 @@ class RouteCollectorTest extends TestCase
         $route = $collector->retrieveRouteByName('something');
         self::assertEquals('/foo', $route->getPath());
     }
+
+    public function testThatRetrievingRoutesByNameIsCaseSensitive(): void
+    {
+        $this->router->expects(self::once())
+            ->method('addRoute')
+            ->willReturnArgument(0);
+
+        $this->collector->get('/foo', $this->noopMiddleware, 'something');
+        $this->expectException(Exception\RouteCannotBeFoundException::class);
+        $this->expectDeprecationMessage('A route with the name "SOMETHING" has not been registered');
+        $this->collector->retrieveRouteByName('SOMETHING');
+    }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| New Feature   | yes
| RFC           | yes

### Description

Being able to retrieve routes from the collector by name is a feature that would be useful to me… In summary `RouteCollector` gets 2 new methods `routeExists(string $name): bool` and `retrieveRouteByName(string $name): Route`. The latter throws a `RouteCannotBeFoundException` if it has not been registered.

Currently, the first route wins when duplicate detection is disabled. It might be better to throw 'AmbiguousRouteException' when > 1 route is found with the same name and duplicate detection has been disabled - This might be complimented by an additional method that returns an array with zero or more matching routes and no exceptions.

I'd be happy to create another pull targeting 4.0 with the methods added to the interface and also write up pulls for any descendants in other packages - but I'm not sure there are any.

😃
