### PR TITLE
Mark all declared symbols as `@final` to discourage inheritance and allow `final` in next major release

### DIFF
--- a/src/DuplicateRouteDetector.php
+++ b/src/DuplicateRouteDetector.php
@@ -7,6 +7,7 @@ namespace Mezzio\Router;
 use function implode;
 use function sprintf;
 
+/** @final */
 final class DuplicateRouteDetector
 {
     private const ROUTE_SEARCH_ANY     = 'any';

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -6,7 +6,6 @@ namespace Mezzio\Router\Exception;
 
 use RuntimeException as PhpRuntimeException;
 
-/** @final */
 class RuntimeException extends PhpRuntimeException implements ExceptionInterface
 {
 }

--- a/src/Middleware/DispatchMiddleware.php
+++ b/src/Middleware/DispatchMiddleware.php
@@ -17,6 +17,8 @@ use Psr\Http\Server\RequestHandlerInterface;
  * delegates request processing to the handler.
  *
  * Otherwise, it delegates processing to the route result.
+ *
+ * @final
  */
 class DispatchMiddleware implements MiddlewareInterface
 {

--- a/src/Middleware/DispatchMiddlewareFactory.php
+++ b/src/Middleware/DispatchMiddlewareFactory.php
@@ -6,6 +6,7 @@ namespace Mezzio\Router\Middleware;
 
 use Psr\Container\ContainerInterface;
 
+/** @final */
 class DispatchMiddlewareFactory
 {
     public function __invoke(ContainerInterface $container): DispatchMiddleware

--- a/src/Middleware/ImplicitHeadMiddleware.php
+++ b/src/Middleware/ImplicitHeadMiddleware.php
@@ -37,6 +37,8 @@ use Psr\Http\Server\RequestHandlerInterface;
  * If the route instance supports GET requests, the middleware dispatches
  * the next layer, but alters the request passed to use the GET method;
  * it then provides an empty response body to the returned response.
+ *
+ * @final
  */
 class ImplicitHeadMiddleware implements MiddlewareInterface
 {

--- a/src/Middleware/ImplicitHeadMiddlewareFactory.php
+++ b/src/Middleware/ImplicitHeadMiddlewareFactory.php
@@ -18,6 +18,8 @@ use Psr\Http\Message\StreamInterface;
  *   instance of that interface.
  * - Psr\Http\Message\StreamInterface, which should resolve to a callable
  *   that will produce an empty Psr\Http\Message\StreamInterface instance.
+ *
+ * @final
  */
 class ImplicitHeadMiddlewareFactory
 {

--- a/src/Middleware/ImplicitOptionsMiddleware.php
+++ b/src/Middleware/ImplicitOptionsMiddleware.php
@@ -40,6 +40,8 @@ use function is_callable;
  * - and the `Route` instance defines implicit OPTIONS.
  *
  * In all other circumstances, it will return the result of the delegate.
+ *
+ * @final
  */
 class ImplicitOptionsMiddleware implements MiddlewareInterface
 {

--- a/src/Middleware/ImplicitOptionsMiddlewareFactory.php
+++ b/src/Middleware/ImplicitOptionsMiddlewareFactory.php
@@ -14,6 +14,8 @@ use Psr\Container\ContainerInterface;
  *
  * - Psr\Http\Message\ResponseInterface, which should resolve to a callable
  *   that will produce an empty Psr\Http\Message\ResponseInterface instance.
+ *
+ * @final
  */
 class ImplicitOptionsMiddlewareFactory
 {

--- a/src/Middleware/MethodNotAllowedMiddleware.php
+++ b/src/Middleware/MethodNotAllowedMiddleware.php
@@ -28,6 +28,8 @@ use function is_callable;
  *
  * If no route result is composed, and/or it's not the result of a method
  * failure, it passes handling to the provided handler.
+ *
+ * @final
  */
 class MethodNotAllowedMiddleware implements MiddlewareInterface
 {

--- a/src/Middleware/MethodNotAllowedMiddlewareFactory.php
+++ b/src/Middleware/MethodNotAllowedMiddlewareFactory.php
@@ -14,6 +14,8 @@ use Psr\Container\ContainerInterface;
  *
  * - Psr\Http\Message\ResponseInterface, which should resolve to a callable
  *   that will produce an empty Psr\Http\Message\ResponseInterface instance.
+ *
+ * @final
  */
 class MethodNotAllowedMiddlewareFactory
 {

--- a/src/Middleware/RouteMiddleware.php
+++ b/src/Middleware/RouteMiddleware.php
@@ -20,6 +20,8 @@ use Psr\Http\Server\RequestHandlerInterface;
  *
  * If routing succeeds, injects the request passed to the handler with any
  * matched parameters as well.
+ *
+ * @final
  */
 class RouteMiddleware implements MiddlewareInterface
 {

--- a/src/Middleware/RouteMiddlewareFactory.php
+++ b/src/Middleware/RouteMiddlewareFactory.php
@@ -17,6 +17,8 @@ use function assert;
  *
  * - Mezzio\Router\RouterInterface, which should resolve to
  *   a class implementing that interface.
+ *
+ * @final
  */
 class RouteMiddlewareFactory
 {

--- a/src/Route.php
+++ b/src/Route.php
@@ -32,6 +32,8 @@ use function strtoupper;
  * for how segments of a route match, or even default values to use. These may
  * be provided after instantiation via the "options" property and related
  * setOptions() method.
+ *
+ * @final
  */
 class Route implements MiddlewareInterface
 {

--- a/src/RouteCollector.php
+++ b/src/RouteCollector.php
@@ -25,6 +25,8 @@ use Psr\Http\Server\MiddlewareInterface;
  * Internally, the class performs some checks for duplicate routes when
  * attaching via one of the exposed methods, and will raise an exception when a
  * collision occurs.
+ *
+ * @final
  */
 class RouteCollector implements RouteCollectorInterface
 {

--- a/src/RouteCollectorFactory.php
+++ b/src/RouteCollectorFactory.php
@@ -18,6 +18,8 @@ use function sprintf;
  *
  * - Mezzio\Router\RouterInterface, which should resolve to
  *   a class implementing that interface.
+ *
+ * @final
  */
 class RouteCollectorFactory
 {

--- a/src/RouteResult.php
+++ b/src/RouteResult.php
@@ -30,6 +30,8 @@ use function assert;
  *
  * RouteResult instances are consumed by the Application in the routing
  * middleware.
+ *
+ * @final
  */
 class RouteResult implements MiddlewareInterface
 {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| QA            | yes

### Description

Marks all classes as soft `@final` to signal that the next major will/could add the `final` keyword to the class.

Also removes `@final` on `RuntimeException` as this is extended by pkg specific exceptions in `mezzio-fastroute` for example
