### PR TITLE
Drop support for PHP 8.0 and upgrade to PHPUnit 10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /.phpcs-cache
-/.phpunit.result.cache
+/.phpunit.cache
 /clover.xml
-/coveralls-upload.json
 /phpunit.xml
 /vendor/

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
             "composer/package-versions-deprecated": true
         },
         "platform": {
-            "php": "8.0.99"
+            "php": "8.1.99"
         }
     },
     "extra": {
@@ -35,7 +35,7 @@
         }
     },
     "require": {
-        "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
+        "php": "~8.1.0 || ~8.2.0",
         "fig/http-message-util": "^1.1.2",
         "psr/container": "^1.0 || ^2.0",
         "psr/http-factory": "^1.0",
@@ -51,9 +51,9 @@
         "laminas/laminas-coding-standard": "~2.5.0",
         "laminas/laminas-diactoros": "^2.24",
         "laminas/laminas-stratigility": "^3.9.0",
-        "phpunit/phpunit": "^9.5.27",
+        "phpunit/phpunit": "^10.0.4",
         "psalm/plugin-phpunit": "^0.18.4",
-        "vimeo/psalm": "^5.4"
+        "vimeo/psalm": "^5.6"
     },
     "suggest": {
         "mezzio/mezzio-aurarouter": "^3.0 to use the Aura.Router routing adapter",

--- a/composer.json
+++ b/composer.json
@@ -51,9 +51,9 @@
         "laminas/laminas-coding-standard": "~2.5.0",
         "laminas/laminas-diactoros": "^2.24",
         "laminas/laminas-stratigility": "^3.9.0",
-        "phpunit/phpunit": "^10.0.4",
+        "phpunit/phpunit": "^10.0.12",
         "psalm/plugin-phpunit": "^0.18.4",
-        "vimeo/psalm": "^5.6"
+        "vimeo/psalm": "^5.7.7"
     },
     "suggest": {
         "mezzio/mezzio-aurarouter": "^3.0 to use the Aura.Router routing adapter",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "62b2bc2721c3529849c53f63729378c4",
+    "content-hash": "6916df32506a7bb9a736e3aa00ed0fd3",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -967,76 +967,6 @@
             "time": "2019-12-04T15:06:13+00:00"
         },
         {
-            "name": "doctrine/instantiator",
-            "version": "1.5.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
-                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1 || ^8.0"
-            },
-            "require-dev": {
-                "doctrine/coding-standard": "^9 || ^11",
-                "ext-pdo": "*",
-                "ext-phar": "*",
-                "phpbench/phpbench": "^0.16 || ^1",
-                "phpstan/phpstan": "^1.4",
-                "phpstan/phpstan-phpunit": "^1",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "vimeo/psalm": "^4.30 || ^5.4"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com",
-                    "homepage": "https://ocramius.github.io/"
-                }
-            ],
-            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
-            "keywords": [
-                "constructor",
-                "instantiate"
-            ],
-            "support": {
-                "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/1.5.0"
-            },
-            "funding": [
-                {
-                    "url": "https://www.doctrine-project.org/sponsorship.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://www.patreon.com/phpdoctrine",
-                    "type": "patreon"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-12-30T00:15:36+00:00"
-        },
-        {
             "name": "felixfbecker/advanced-json-rpc",
             "version": "v3.2.1",
             "source": {
@@ -1981,16 +1911,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.24",
+            "version": "10.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "2cf940ebc6355a9d430462811b5aaa308b174bed"
+                "reference": "bf4fbc9c13af7da12b3ea807574fb460f255daba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2cf940ebc6355a9d430462811b5aaa308b174bed",
-                "reference": "2cf940ebc6355a9d430462811b5aaa308b174bed",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/bf4fbc9c13af7da12b3ea807574fb460f255daba",
+                "reference": "bf4fbc9c13af7da12b3ea807574fb460f255daba",
                 "shasum": ""
             },
             "require": {
@@ -1998,18 +1928,18 @@
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
                 "nikic/php-parser": "^4.14",
-                "php": ">=7.3",
-                "phpunit/php-file-iterator": "^3.0.3",
-                "phpunit/php-text-template": "^2.0.2",
-                "sebastian/code-unit-reverse-lookup": "^2.0.2",
-                "sebastian/complexity": "^2.0",
-                "sebastian/environment": "^5.1.2",
-                "sebastian/lines-of-code": "^1.0.3",
-                "sebastian/version": "^3.0.1",
+                "php": ">=8.1",
+                "phpunit/php-file-iterator": "^4.0",
+                "phpunit/php-text-template": "^3.0",
+                "sebastian/code-unit-reverse-lookup": "^3.0",
+                "sebastian/complexity": "^3.0",
+                "sebastian/environment": "^6.0",
+                "sebastian/lines-of-code": "^2.0",
+                "sebastian/version": "^4.0",
                 "theseer/tokenizer": "^1.2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "suggest": {
                 "ext-pcov": "*",
@@ -2018,7 +1948,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.2-dev"
+                    "dev-main": "10.0-dev"
                 }
             },
             "autoload": {
@@ -2046,7 +1976,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.24"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.0.0"
             },
             "funding": [
                 {
@@ -2054,32 +1984,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-26T08:26:55+00:00"
+            "time": "2023-02-03T07:14:34+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "3.0.6",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+                "reference": "7d66d4e816d34e90acec9db9d8d94b5cfbfe926f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/7d66d4e816d34e90acec9db9d8d94b5cfbfe926f",
+                "reference": "7d66d4e816d34e90acec9db9d8d94b5cfbfe926f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -2106,7 +2036,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.0.0"
             },
             "funding": [
                 {
@@ -2114,28 +2044,28 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-12-02T12:48:52+00:00"
+            "time": "2023-02-03T06:55:11+00:00"
         },
         {
             "name": "phpunit/php-invoker",
-            "version": "3.1.1",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
                 "ext-pcntl": "*",
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "suggest": {
                 "ext-pcntl": "*"
@@ -2143,7 +2073,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -2169,7 +2099,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
-                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/4.0.0"
             },
             "funding": [
                 {
@@ -2177,32 +2107,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:58:55+00:00"
+            "time": "2023-02-03T06:56:09+00:00"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "2.0.4",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+                "reference": "9f3d3709577a527025f55bcf0f7ab8052c8bb37d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/9f3d3709577a527025f55bcf0f7ab8052c8bb37d",
+                "reference": "9f3d3709577a527025f55bcf0f7ab8052c8bb37d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2228,7 +2158,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/3.0.0"
             },
             "funding": [
                 {
@@ -2236,32 +2166,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T05:33:50+00:00"
+            "time": "2023-02-03T06:56:46+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "5.0.3",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -2287,7 +2217,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/6.0.0"
             },
             "funding": [
                 {
@@ -2295,24 +2225,23 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:16:10+00:00"
+            "time": "2023-02-03T06:57:52+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.28",
+            "version": "10.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "954ca3113a03bf780d22f07bf055d883ee04b65e"
+                "reference": "6be2d07cce2c7f812db007825a57da3b08972eaf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/954ca3113a03bf780d22f07bf055d883ee04b65e",
-                "reference": "954ca3113a03bf780d22f07bf055d883ee04b65e",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/6be2d07cce2c7f812db007825a57da3b08972eaf",
+                "reference": "6be2d07cce2c7f812db007825a57da3b08972eaf",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.3.1 || ^2",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
@@ -2322,27 +2251,26 @@
                 "myclabs/deep-copy": "^1.10.1",
                 "phar-io/manifest": "^2.0.3",
                 "phar-io/version": "^3.0.2",
-                "php": ">=7.3",
-                "phpunit/php-code-coverage": "^9.2.13",
-                "phpunit/php-file-iterator": "^3.0.5",
-                "phpunit/php-invoker": "^3.1.1",
-                "phpunit/php-text-template": "^2.0.3",
-                "phpunit/php-timer": "^5.0.2",
-                "sebastian/cli-parser": "^1.0.1",
-                "sebastian/code-unit": "^1.0.6",
-                "sebastian/comparator": "^4.0.8",
-                "sebastian/diff": "^4.0.3",
-                "sebastian/environment": "^5.1.3",
-                "sebastian/exporter": "^4.0.5",
-                "sebastian/global-state": "^5.0.1",
-                "sebastian/object-enumerator": "^4.0.3",
-                "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^3.2",
-                "sebastian/version": "^3.0.2"
+                "php": ">=8.1",
+                "phpunit/php-code-coverage": "^10.0",
+                "phpunit/php-file-iterator": "^4.0",
+                "phpunit/php-invoker": "^4.0",
+                "phpunit/php-text-template": "^3.0",
+                "phpunit/php-timer": "^6.0",
+                "sebastian/cli-parser": "^2.0",
+                "sebastian/code-unit": "^2.0",
+                "sebastian/comparator": "^5.0",
+                "sebastian/diff": "^5.0",
+                "sebastian/environment": "^6.0",
+                "sebastian/exporter": "^5.0",
+                "sebastian/global-state": "^6.0",
+                "sebastian/object-enumerator": "^5.0",
+                "sebastian/recursion-context": "^5.0",
+                "sebastian/type": "^4.0",
+                "sebastian/version": "^4.0"
             },
             "suggest": {
-                "ext-soap": "*",
-                "ext-xdebug": "*"
+                "ext-soap": "*"
             },
             "bin": [
                 "phpunit"
@@ -2350,7 +2278,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.5-dev"
+                    "dev-main": "10.0-dev"
                 }
             },
             "autoload": {
@@ -2381,7 +2309,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.28"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.0.4"
             },
             "funding": [
                 {
@@ -2397,7 +2325,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-14T12:32:24+00:00"
+            "time": "2023-02-05T16:23:38+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -2511,28 +2439,28 @@
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "1.0.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2"
+                "reference": "efdc130dbbbb8ef0b545a994fd811725c5282cae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/442e7c7e687e42adc03470c7b668bc4b2402c0b2",
-                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/efdc130dbbbb8ef0b545a994fd811725c5282cae",
+                "reference": "efdc130dbbbb8ef0b545a994fd811725c5282cae",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -2555,7 +2483,7 @@
             "homepage": "https://github.com/sebastianbergmann/cli-parser",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.1"
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/2.0.0"
             },
             "funding": [
                 {
@@ -2563,32 +2491,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:08:49+00:00"
+            "time": "2023-02-03T06:58:15+00:00"
         },
         {
             "name": "sebastian/code-unit",
-            "version": "1.0.8",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/a81fee9eef0b7a76af11d121767abc44c104e503",
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -2611,7 +2539,7 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/2.0.0"
             },
             "funding": [
                 {
@@ -2619,32 +2547,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:08:54+00:00"
+            "time": "2023-02-03T06:58:43+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
-            "version": "2.0.3",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2666,7 +2594,7 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/3.0.0"
             },
             "funding": [
                 {
@@ -2674,34 +2602,36 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:30:19+00:00"
+            "time": "2023-02-03T06:59:15+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "4.0.8",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a"
+                "reference": "72f01e6586e0caf6af81297897bd112eb7e9627c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/fa0f136dd2334583309d32b62544682ee972b51a",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/72f01e6586e0caf6af81297897bd112eb7e9627c",
+                "reference": "72f01e6586e0caf6af81297897bd112eb7e9627c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/diff": "^4.0",
-                "sebastian/exporter": "^4.0"
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/diff": "^5.0",
+                "sebastian/exporter": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -2740,7 +2670,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.8"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.0"
             },
             "funding": [
                 {
@@ -2748,33 +2678,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-14T12:41:17+00:00"
+            "time": "2023-02-03T07:07:16+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "2.0.2",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88"
+                "reference": "e67d240970c9dc7ea7b2123a6d520e334dd61dc6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/739b35e53379900cc9ac327b2147867b8b6efd88",
-                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/e67d240970c9dc7ea7b2123a6d520e334dd61dc6",
+                "reference": "e67d240970c9dc7ea7b2123a6d520e334dd61dc6",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.7",
-                "php": ">=7.3"
+                "nikic/php-parser": "^4.10",
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2797,7 +2727,7 @@
             "homepage": "https://github.com/sebastianbergmann/complexity",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.2"
+                "source": "https://github.com/sebastianbergmann/complexity/tree/3.0.0"
             },
             "funding": [
                 {
@@ -2805,33 +2735,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T15:52:27+00:00"
+            "time": "2023-02-03T06:59:47+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.4",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d"
+                "reference": "70dd1b20bc198da394ad542e988381b44e64e39f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3461e3fccc7cfdfc2720be910d3bd73c69be590d",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/70dd1b20bc198da394ad542e988381b44e64e39f",
+                "reference": "70dd1b20bc198da394ad542e988381b44e64e39f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3",
+                "phpunit/phpunit": "^10.0",
                 "symfony/process": "^4.2 || ^5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -2863,7 +2793,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/diff/tree/5.0.0"
             },
             "funding": [
                 {
@@ -2871,27 +2801,27 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:10:38+00:00"
+            "time": "2023-02-03T07:00:31+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "5.1.4",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "1b5dff7bb151a4db11d49d90e5408e4e938270f7"
+                "reference": "b6f3694c6386c7959915a0037652e0c40f6f69cc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/1b5dff7bb151a4db11d49d90e5408e4e938270f7",
-                "reference": "1b5dff7bb151a4db11d49d90e5408e4e938270f7",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/b6f3694c6386c7959915a0037652e0c40f6f69cc",
+                "reference": "b6f3694c6386c7959915a0037652e0c40f6f69cc",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -2899,7 +2829,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.1-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -2918,7 +2848,7 @@
                 }
             ],
             "description": "Provides functionality to handle HHVM/PHP environments",
-            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "homepage": "https://github.com/sebastianbergmann/environment",
             "keywords": [
                 "Xdebug",
                 "environment",
@@ -2926,7 +2856,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.4"
+                "source": "https://github.com/sebastianbergmann/environment/tree/6.0.0"
             },
             "funding": [
                 {
@@ -2934,34 +2864,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-04-03T09:37:03+00:00"
+            "time": "2023-02-03T07:03:04+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.5",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d"
+                "reference": "f3ec4bf931c0b31e5b413f5b4fc970a7d03338c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
-                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/f3ec4bf931c0b31e5b413f5b4fc970a7d03338c0",
+                "reference": "f3ec4bf931c0b31e5b413f5b4fc970a7d03338c0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/recursion-context": "^4.0"
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
-                "ext-mbstring": "*",
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -3003,7 +2933,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.5"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/5.0.0"
             },
             "funding": [
                 {
@@ -3011,38 +2941,35 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-14T06:03:37+00:00"
+            "time": "2023-02-03T07:06:49+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.5",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2"
+                "reference": "aab257c712de87b90194febd52e4d184551c2d44"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/0ca8db5a5fc9c8646244e629625ac486fa286bf2",
-                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/aab257c712de87b90194febd52e4d184551c2d44",
+                "reference": "aab257c712de87b90194febd52e4d184551c2d44",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^9.3"
-            },
-            "suggest": {
-                "ext-uopz": "*"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -3067,7 +2994,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.5"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.0"
             },
             "funding": [
                 {
@@ -3075,33 +3002,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-02-14T08:28:10+00:00"
+            "time": "2023-02-03T07:07:38+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "1.0.3",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc"
+                "reference": "17c4d940ecafb3d15d2cf916f4108f664e28b130"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/c1c2e997aa3146983ed888ad08b15470a2e22ecc",
-                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/17c4d940ecafb3d15d2cf916f4108f664e28b130",
+                "reference": "17c4d940ecafb3d15d2cf916f4108f664e28b130",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.6",
-                "php": ">=7.3"
+                "nikic/php-parser": "^4.10",
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -3124,7 +3051,7 @@
             "homepage": "https://github.com/sebastianbergmann/lines-of-code",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.3"
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.0"
             },
             "funding": [
                 {
@@ -3132,34 +3059,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-28T06:42:11+00:00"
+            "time": "2023-02-03T07:08:02+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "4.0.4",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -3181,7 +3108,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/5.0.0"
             },
             "funding": [
                 {
@@ -3189,32 +3116,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:12:34+00:00"
+            "time": "2023-02-03T07:08:32+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "2.0.4",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/24ed13d98130f0e7122df55d06c5c4942a577957",
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -3236,7 +3163,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/3.0.0"
             },
             "funding": [
                 {
@@ -3244,32 +3171,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:14:26+00:00"
+            "time": "2023-02-03T07:06:18+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "4.0.4",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172"
+                "reference": "05909fb5bc7df4c52992396d0116aed689f93712"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/cd9d8cf3c5804de4341c283ed787f099f5506172",
-                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/05909fb5bc7df4c52992396d0116aed689f93712",
+                "reference": "05909fb5bc7df4c52992396d0116aed689f93712",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -3296,10 +3223,10 @@
                 }
             ],
             "description": "Provides functionality to recursively process PHP variables",
-            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/5.0.0"
             },
             "funding": [
                 {
@@ -3307,87 +3234,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:17:30+00:00"
-        },
-        {
-            "name": "sebastian/resource-operations",
-            "version": "3.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
-                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Provides a list of PHP built-in functions that operate on resources",
-            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
-                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.3"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-09-28T06:45:17+00:00"
+            "time": "2023-02-03T07:05:40+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "3.2.0",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e"
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e",
-                "reference": "fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/462699a16464c3944eefc02ebdd77882bd3925bf",
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -3410,7 +3282,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/3.2.0"
+                "source": "https://github.com/sebastianbergmann/type/tree/4.0.0"
             },
             "funding": [
                 {
@@ -3418,29 +3290,29 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-12T14:47:03+00:00"
+            "time": "2023-02-03T07:10:45+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "3.0.2",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+                "reference": "5facf5a20311ac44f79221274cdeb6c569ca11dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/5facf5a20311ac44f79221274cdeb6c569ca11dd",
+                "reference": "5facf5a20311ac44f79221274cdeb6c569ca11dd",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -3463,7 +3335,7 @@
             "homepage": "https://github.com/sebastianbergmann/version",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
-                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+                "source": "https://github.com/sebastianbergmann/version/tree/4.0.0"
             },
             "funding": [
                 {
@@ -3471,7 +3343,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:39:44+00:00"
+            "time": "2023-02-03T07:11:37+00:00"
         },
         {
             "name": "slevomat/coding-standard",
@@ -3656,20 +3528,21 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.0.19",
+            "version": "v6.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "c3ebc83d031b71c39da318ca8b7a07ecc67507ed"
+                "reference": "3e294254f2191762c1d137aed4b94e966965e985"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/c3ebc83d031b71c39da318ca8b7a07ecc67507ed",
-                "reference": "c3ebc83d031b71c39da318ca8b7a07ecc67507ed",
+                "url": "https://api.github.com/repos/symfony/console/zipball/3e294254f2191762c1d137aed4b94e966965e985",
+                "reference": "3e294254f2191762c1d137aed4b94e966965e985",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.1|^3",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/service-contracts": "^1.1|^2|^3",
                 "symfony/string": "^5.4|^6.0"
@@ -3731,7 +3604,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.0.19"
+                "source": "https://github.com/symfony/console/tree/v6.2.5"
             },
             "funding": [
                 {
@@ -3747,24 +3620,91 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:36:10+00:00"
+            "time": "2023-01-01T08:38:09+00:00"
         },
         {
-            "name": "symfony/filesystem",
-            "version": "v6.0.19",
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.2.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/filesystem.git",
-                "reference": "3d49eec03fda1f0fc19b7349fbbe55ebc1004214"
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "1ee04c65529dea5d8744774d474e7cbd2f1206d3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/3d49eec03fda1f0fc19b7349fbbe55ebc1004214",
-                "reference": "3d49eec03fda1f0fc19b7349fbbe55ebc1004214",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/1ee04c65529dea5d8744774d474e7cbd2f1206d3",
+                "reference": "1ee04c65529dea5d8744774d474e7cbd2f1206d3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.3-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-11-25T10:21:52+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v6.2.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "e59e8a4006afd7f5654786a83b4fcb8da98f4593"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/e59e8a4006afd7f5654786a83b4fcb8da98f4593",
+                "reference": "e59e8a4006afd7f5654786a83b4fcb8da98f4593",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-mbstring": "~1.8"
             },
@@ -3794,7 +3734,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v6.0.19"
+                "source": "https://github.com/symfony/filesystem/tree/v6.2.5"
             },
             "funding": [
                 {
@@ -3810,7 +3750,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-20T17:44:14+00:00"
+            "time": "2023-01-20T17:45:48+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -4144,20 +4084,20 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.0.2",
+            "version": "v3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "d78d39c1599bd1188b8e26bb341da52c3c6d8a66"
+                "reference": "aac98028c69df04ee77eb69b96b86ee51fbf4b75"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d78d39c1599bd1188b8e26bb341da52c3c6d8a66",
-                "reference": "d78d39c1599bd1188b8e26bb341da52c3c6d8a66",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/aac98028c69df04ee77eb69b96b86ee51fbf4b75",
+                "reference": "aac98028c69df04ee77eb69b96b86ee51fbf4b75",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
                 "psr/container": "^2.0"
             },
             "conflict": {
@@ -4169,7 +4109,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "3.3-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -4179,7 +4119,10 @@
             "autoload": {
                 "psr-4": {
                     "Symfony\\Contracts\\Service\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -4206,7 +4149,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.0.2"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.2.0"
             },
             "funding": [
                 {
@@ -4222,24 +4165,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-30T19:17:58+00:00"
+            "time": "2022-11-25T10:21:52+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v6.0.19",
+            "version": "v6.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "d9e72497367c23e08bf94176d2be45b00a9d232a"
+                "reference": "b2dac0fa27b1ac0f9c0c0b23b43977f12308d0b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/d9e72497367c23e08bf94176d2be45b00a9d232a",
-                "reference": "d9e72497367c23e08bf94176d2be45b00a9d232a",
+                "url": "https://api.github.com/repos/symfony/string/zipball/b2dac0fa27b1ac0f9c0c0b23b43977f12308d0b0",
+                "reference": "b2dac0fa27b1ac0f9c0c0b23b43977f12308d0b0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-intl-grapheme": "~1.0",
                 "symfony/polyfill-intl-normalizer": "~1.0",
@@ -4251,6 +4194,7 @@
             "require-dev": {
                 "symfony/error-handler": "^5.4|^6.0",
                 "symfony/http-client": "^5.4|^6.0",
+                "symfony/intl": "^6.2",
                 "symfony/translation-contracts": "^2.0|^3.0",
                 "symfony/var-exporter": "^5.4|^6.0"
             },
@@ -4291,7 +4235,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.0.19"
+                "source": "https://github.com/symfony/string/tree/v6.2.5"
             },
             "funding": [
                 {
@@ -4307,7 +4251,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:36:10+00:00"
+            "time": "2023-01-01T08:38:09+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -4525,11 +4469,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
+        "php": "~8.1.0 || ~8.2.0"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "8.0.99"
+        "php": "8.1.99"
     },
     "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6916df32506a7bb9a736e3aa00ed0fd3",
+    "content-hash": "e863b80600da70eea09bd2abc454ef16",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -1069,16 +1069,16 @@
         },
         {
             "name": "fidry/cpu-core-counter",
-            "version": "0.4.1",
+            "version": "0.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theofidry/cpu-core-counter.git",
-                "reference": "79261cc280aded96d098e1b0e0ba0c4881b432c2"
+                "reference": "b58e5a3933e541dc286cc91fc4f3898bbc6f1623"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/79261cc280aded96d098e1b0e0ba0c4881b432c2",
-                "reference": "79261cc280aded96d098e1b0e0ba0c4881b432c2",
+                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/b58e5a3933e541dc286cc91fc4f3898bbc6f1623",
+                "reference": "b58e5a3933e541dc286cc91fc4f3898bbc6f1623",
                 "shasum": ""
             },
             "require": {
@@ -1118,7 +1118,7 @@
             ],
             "support": {
                 "issues": "https://github.com/theofidry/cpu-core-counter/issues",
-                "source": "https://github.com/theofidry/cpu-core-counter/tree/0.4.1"
+                "source": "https://github.com/theofidry/cpu-core-counter/tree/0.5.1"
             },
             "funding": [
                 {
@@ -1126,7 +1126,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-12-16T22:01:02+00:00"
+            "time": "2022-12-24T12:35:10+00:00"
         },
         {
             "name": "laminas/laminas-coding-standard",
@@ -1911,23 +1911,23 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "10.0.0",
+            "version": "10.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "bf4fbc9c13af7da12b3ea807574fb460f255daba"
+                "reference": "b9c21a93dd8c8eed79879374884ee733259475cc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/bf4fbc9c13af7da12b3ea807574fb460f255daba",
-                "reference": "bf4fbc9c13af7da12b3ea807574fb460f255daba",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/b9c21a93dd8c8eed79879374884ee733259475cc",
+                "reference": "b9c21a93dd8c8eed79879374884ee733259475cc",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.14",
+                "nikic/php-parser": "^4.15",
                 "php": ">=8.1",
                 "phpunit/php-file-iterator": "^4.0",
                 "phpunit/php-text-template": "^3.0",
@@ -1976,7 +1976,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.0.0"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.0.1"
             },
             "funding": [
                 {
@@ -1984,20 +1984,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:14:34+00:00"
+            "time": "2023-02-25T05:35:03+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "4.0.0",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "7d66d4e816d34e90acec9db9d8d94b5cfbfe926f"
+                "reference": "fd9329ab3368f59fe1fe808a189c51086bd4b6bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/7d66d4e816d34e90acec9db9d8d94b5cfbfe926f",
-                "reference": "7d66d4e816d34e90acec9db9d8d94b5cfbfe926f",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/fd9329ab3368f59fe1fe808a189c51086bd4b6bd",
+                "reference": "fd9329ab3368f59fe1fe808a189c51086bd4b6bd",
                 "shasum": ""
             },
             "require": {
@@ -2036,7 +2036,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.0.0"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.0.1"
             },
             "funding": [
                 {
@@ -2044,7 +2044,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:55:11+00:00"
+            "time": "2023-02-10T16:53:14+00:00"
         },
         {
             "name": "phpunit/php-invoker",
@@ -2229,16 +2229,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.0.4",
+            "version": "10.0.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "6be2d07cce2c7f812db007825a57da3b08972eaf"
+                "reference": "87d5cfdb4ecf440fb9f08b636b1152be433fc6f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/6be2d07cce2c7f812db007825a57da3b08972eaf",
-                "reference": "6be2d07cce2c7f812db007825a57da3b08972eaf",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/87d5cfdb4ecf440fb9f08b636b1152be433fc6f1",
+                "reference": "87d5cfdb4ecf440fb9f08b636b1152be433fc6f1",
                 "shasum": ""
             },
             "require": {
@@ -2309,7 +2309,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.0.4"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.0.12"
             },
             "funding": [
                 {
@@ -2325,7 +2325,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-05T16:23:38+00:00"
+            "time": "2023-02-25T06:05:15+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -3294,16 +3294,16 @@
         },
         {
             "name": "sebastian/version",
-            "version": "4.0.0",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "5facf5a20311ac44f79221274cdeb6c569ca11dd"
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/5facf5a20311ac44f79221274cdeb6c569ca11dd",
-                "reference": "5facf5a20311ac44f79221274cdeb6c569ca11dd",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17",
                 "shasum": ""
             },
             "require": {
@@ -3335,7 +3335,7 @@
             "homepage": "https://github.com/sebastianbergmann/version",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
-                "source": "https://github.com/sebastianbergmann/version/tree/4.0.0"
+                "source": "https://github.com/sebastianbergmann/version/tree/4.0.1"
             },
             "funding": [
                 {
@@ -3343,7 +3343,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:11:37+00:00"
+            "time": "2023-02-07T11:34:05+00:00"
         },
         {
             "name": "slevomat/coding-standard",
@@ -3408,26 +3408,25 @@
         },
         {
             "name": "spatie/array-to-xml",
-            "version": "2.17.1",
+            "version": "3.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/array-to-xml.git",
-                "reference": "5cbec9c6ab17e320c58a259f0cebe88bde4a7c46"
+                "reference": "13f76acef5362d15c71ae1ac6350cc3df5e25e43"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/5cbec9c6ab17e320c58a259f0cebe88bde4a7c46",
-                "reference": "5cbec9c6ab17e320c58a259f0cebe88bde4a7c46",
+                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/13f76acef5362d15c71ae1ac6350cc3df5e25e43",
+                "reference": "13f76acef5362d15c71ae1ac6350cc3df5e25e43",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
-                "php": "^7.4|^8.0"
+                "php": "^8.0"
             },
             "require-dev": {
                 "mockery/mockery": "^1.2",
                 "pestphp/pest": "^1.21",
-                "phpunit/phpunit": "^9.0",
                 "spatie/pest-plugin-snapshots": "^1.1"
             },
             "type": "library",
@@ -3456,7 +3455,7 @@
                 "xml"
             ],
             "support": {
-                "source": "https://github.com/spatie/array-to-xml/tree/2.17.1"
+                "source": "https://github.com/spatie/array-to-xml/tree/3.1.5"
             },
             "funding": [
                 {
@@ -3468,20 +3467,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-12-26T08:22:07+00:00"
+            "time": "2022-12-24T13:43:51+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.7.1",
+            "version": "3.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619"
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
-                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
                 "shasum": ""
             },
             "require": {
@@ -3517,14 +3516,15 @@
             "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
-                "standards"
+                "standards",
+                "static analysis"
             ],
             "support": {
                 "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2022-06-18T07:21:10+00:00"
+            "time": "2023-02-22T23:07:41+00:00"
         },
         {
             "name": "symfony/console",
@@ -4305,16 +4305,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "5.6.0",
+            "version": "5.7.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "e784128902dfe01d489c4123d69918a9f3c1eac5"
+                "reference": "e028ba46ba0d7f9a78bc3201c251e137383e145f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/e784128902dfe01d489c4123d69918a9f3c1eac5",
-                "reference": "e784128902dfe01d489c4123d69918a9f3c1eac5",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/e028ba46ba0d7f9a78bc3201c251e137383e145f",
+                "reference": "e028ba46ba0d7f9a78bc3201c251e137383e145f",
                 "shasum": ""
             },
             "require": {
@@ -4333,12 +4333,12 @@
                 "ext-tokenizer": "*",
                 "felixfbecker/advanced-json-rpc": "^3.1",
                 "felixfbecker/language-server-protocol": "^1.5.2",
-                "fidry/cpu-core-counter": "^0.4.0",
+                "fidry/cpu-core-counter": "^0.4.1 || ^0.5.1",
                 "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
                 "nikic/php-parser": "^4.13",
                 "php": "^7.4 || ~8.0.0 || ~8.1.0 || ~8.2.0",
                 "sebastian/diff": "^4.0 || ^5.0",
-                "spatie/array-to-xml": "^2.17.0",
+                "spatie/array-to-xml": "^2.17.0 || ^3.0",
                 "symfony/console": "^4.1.6 || ^5.0 || ^6.0",
                 "symfony/filesystem": "^5.4 || ^6.0"
             },
@@ -4347,13 +4347,13 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.4",
-                "brianium/paratest": "^6.0",
+                "brianium/paratest": "^6.9",
                 "ext-curl": "*",
                 "mockery/mockery": "^1.5",
                 "nunomaduro/mock-final-classes": "^1.1",
                 "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpstan/phpdoc-parser": "^1.6",
-                "phpunit/phpunit": "^9.5",
+                "phpunit/phpunit": "^9.6",
                 "psalm/plugin-mockery": "^1.1",
                 "psalm/plugin-phpunit": "^0.18",
                 "slevomat/coding-standard": "^8.4",
@@ -4399,13 +4399,14 @@
             "keywords": [
                 "code",
                 "inspection",
-                "php"
+                "php",
+                "static analysis"
             ],
             "support": {
                 "issues": "https://github.com/vimeo/psalm/issues",
-                "source": "https://github.com/vimeo/psalm/tree/5.6.0"
+                "source": "https://github.com/vimeo/psalm/tree/5.7.7"
             },
-            "time": "2023-01-23T20:32:47+00:00"
+            "time": "2023-02-25T01:05:07+00:00"
         },
         {
             "name": "webimpress/coding-standard",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,14 +2,20 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="vendor/autoload.php"
-         colors="true">
+         colors="true"
+         displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+         displayDetailsOnSkippedTests="true"
+         displayDetailsOnIncompleteTests="true"
+         cacheDirectory=".phpunit.cache">
     <testsuites>
         <testsuite name="Mezzio Tests">
             <directory>./test</directory>
         </testsuite>
     </testsuites>
-
-    <coverage processUncoveredFiles="true">
+    <coverage>
         <include>
             <directory suffix=".php">src</directory>
         </include>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.4.0@62db5d4f6a7ae0a20f7cc5a4952d730272fc0863">
+<files psalm-version="5.6.0@e784128902dfe01d489c4123d69918a9f3c1eac5">
   <file src="src/Middleware/ImplicitHeadMiddlewareFactory.php">
-    <InvalidArgument occurrences="1">
+    <InvalidArgument>
       <code>$container-&gt;get(StreamInterface::class)</code>
     </InvalidArgument>
   </file>
   <file src="test/InMemoryContainer.php">
-    <MixedReturnStatement occurrences="1">
+    <MixedReturnStatement>
       <code>$this-&gt;services[$id]</code>
     </MixedReturnStatement>
   </file>
   <file src="test/Response/CallableResponseFactoryDecoratorTest.php">
-    <InternalMethod occurrences="1">
+    <InternalMethod>
       <code>new CallableResponseFactoryDecorator(fn (): ResponseInterface =&gt; $this-&gt;response)</code>
     </InternalMethod>
   </file>

--- a/psalm.xml
+++ b/psalm.xml
@@ -5,6 +5,9 @@
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
     errorBaseline="psalm-baseline.xml"
+    findUnusedPsalmSuppress="true"
+    findUnusedBaselineEntry="true"
+    findUnusedCode="false"
 >
     <projectFiles>
         <directory name="src"/>

--- a/src/Test/AbstractImplicitMethodsIntegrationTest.php
+++ b/src/Test/AbstractImplicitMethodsIntegrationTest.php
@@ -20,6 +20,7 @@ use Mezzio\Router\Route;
 use Mezzio\Router\RouteResult;
 use Mezzio\Router\RouterInterface;
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -74,7 +75,7 @@ abstract class AbstractImplicitMethodsIntegrationTest extends TestCase
     /**
      * @psalm-return Generator<non-empty-string,array{0:RequestMethod::*,1:non-empty-list<RequestMethod::*>}>
      */
-    public function method(): Generator
+    public static function method(): Generator
     {
         yield 'HEAD: head, post' => [
             RequestMethod::METHOD_HEAD,
@@ -120,8 +121,8 @@ abstract class AbstractImplicitMethodsIntegrationTest extends TestCase
     /**
      * @psalm-param RequestMethod::* $method
      * @psalm-param non-empty-list<RequestMethod::*> $routes
-     * @dataProvider method
      */
+    #[DataProvider('method')]
     public function testExplicitRequest(string $method, array $routes): void
     {
         $implicitRoute = null;
@@ -186,7 +187,7 @@ abstract class AbstractImplicitMethodsIntegrationTest extends TestCase
     /**
      * @return Generator<non-empty-string,array{0:RequestMethod::*,1:non-empty-list<RequestMethod::*>}>
      */
-    public function withoutImplicitMiddleware(): Generator
+    public static function withoutImplicitMiddleware(): Generator
     {
         // request method, array of allowed methods for a route.
         yield 'HEAD: get'          => [RequestMethod::METHOD_HEAD, [RequestMethod::METHOD_GET]];
@@ -210,8 +211,8 @@ abstract class AbstractImplicitMethodsIntegrationTest extends TestCase
      *
      * @psalm-param RequestMethod::* $requestMethod
      * @psalm-param non-empty-list<RequestMethod::*> $allowedMethods
-     * @dataProvider withoutImplicitMiddleware
      */
+    #[DataProvider('withoutImplicitMiddleware')]
     public function testWithoutImplicitMiddleware(string $requestMethod, array $allowedMethods): void
     {
         $router = $this->getRouter();
@@ -271,14 +272,14 @@ abstract class AbstractImplicitMethodsIntegrationTest extends TestCase
      *     3: array<string,mixed>
      * }>
      */
-    abstract public function implicitRoutesAndRequests(): Generator;
+    abstract public static function implicitRoutesAndRequests(): Generator;
 
     /**
      * @param non-empty-string $routePath
      * @psalm-param array<string,mixed> $routeOptions
      * @psalm-param array<string,mixed> $expectedParams
-     * @dataProvider implicitRoutesAndRequests
      */
+    #[DataProvider('implicitRoutesAndRequests')]
     public function testImplicitHeadRequest(
         string $routePath,
         array $routeOptions,
@@ -366,8 +367,8 @@ abstract class AbstractImplicitMethodsIntegrationTest extends TestCase
     /**
      * @param non-empty-string $routePath
      * @psalm-param array<string,mixed> $routeOptions
-     * @dataProvider implicitRoutesAndRequests
      */
+    #[DataProvider('implicitRoutesAndRequests')]
     public function testImplicitOptionsRequest(
         string $routePath,
         array $routeOptions,

--- a/test/InMemoryContainer.php
+++ b/test/InMemoryContainer.php
@@ -13,12 +13,12 @@ use function array_key_exists;
 final class InMemoryContainer implements ContainerInterface
 {
     /** @var array<string,mixed> */
-    private $services = [];
+    private array $services = [];
 
     /** {@inheritDoc} */
-    public function get($id)
+    public function get($id): mixed
     {
-        if (! $this->has($id)) {
+        if (! array_key_exists($id, $this->services)) {
             throw new class ($id . ' was not found') extends RuntimeException implements NotFoundExceptionInterface {
             };
         }
@@ -32,8 +32,7 @@ final class InMemoryContainer implements ContainerInterface
         return array_key_exists($id, $this->services);
     }
 
-    /** @param mixed $item */
-    public function set(string $id, $item): void
+    public function set(string $id, mixed $item): void
     {
         $this->services[$id] = $item;
     }

--- a/test/Middleware/ImplicitHeadMiddlewareFactoryTest.php
+++ b/test/Middleware/ImplicitHeadMiddlewareFactoryTest.php
@@ -7,12 +7,15 @@ namespace MezzioTest\Router\Middleware;
 use Mezzio\Router\Exception\MissingDependencyException;
 use Mezzio\Router\Middleware\ImplicitHeadMiddlewareFactory;
 use Mezzio\Router\RouterInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\StreamInterface;
 
-/** @covers \Mezzio\Router\Middleware\ImplicitHeadMiddlewareFactory */
+use function in_array;
+
+#[CoversClass(ImplicitHeadMiddlewareFactory::class)]
 final class ImplicitHeadMiddlewareFactoryTest extends TestCase
 {
     /** @var ContainerInterface&MockObject */
@@ -44,8 +47,12 @@ final class ImplicitHeadMiddlewareFactoryTest extends TestCase
     public function testFactoryRaisesExceptionIfStreamFactoryServiceIsMissing(): void
     {
         $this->container
+            ->expects(self::exactly(2))
             ->method('has')
-            ->withConsecutive([RouterInterface::class], [StreamInterface::class])
+            ->with(self::callback(function (string $arg): bool {
+                self::assertTrue(in_array($arg, [RouterInterface::class, StreamInterface::class]));
+                return true;
+            }))
             ->willReturnOnConsecutiveCalls(true, false);
 
         $this->expectException(MissingDependencyException::class);
@@ -62,14 +69,20 @@ final class ImplicitHeadMiddlewareFactoryTest extends TestCase
         $this->container
             ->expects(self::exactly(2))
             ->method('has')
-            ->withConsecutive([RouterInterface::class], [StreamInterface::class])
+            ->with(self::callback(function (string $arg): bool {
+                self::assertTrue(in_array($arg, [RouterInterface::class, StreamInterface::class]));
+                return true;
+            }))
             ->willReturn(true);
 
         $this->container
             ->expects(self::exactly(2))
             ->method('get')
-            ->withConsecutive([RouterInterface::class], [StreamInterface::class])
-            ->willReturn($router, $streamFactory);
+            ->with(self::callback(function (string $arg): bool {
+                self::assertTrue(in_array($arg, [RouterInterface::class, StreamInterface::class]));
+                return true;
+            }))
+            ->willReturnOnConsecutiveCalls($router, $streamFactory);
 
         ($this->factory)($this->container);
     }

--- a/test/Middleware/ImplicitHeadMiddlewareTest.php
+++ b/test/Middleware/ImplicitHeadMiddlewareTest.php
@@ -5,28 +5,24 @@ declare(strict_types=1);
 namespace MezzioTest\Router\Middleware;
 
 use Fig\Http\Message\RequestMethodInterface as RequestMethod;
+use Laminas\Diactoros\Response\TextResponse;
+use Laminas\Diactoros\ServerRequest;
 use Mezzio\Router\Middleware\ImplicitHeadMiddleware;
 use Mezzio\Router\Route;
 use Mezzio\Router\RouteResult;
 use Mezzio\Router\RouterInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
-use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Http\Server\MiddlewareInterface;
 
 /** @covers \Mezzio\Router\Middleware\ImplicitHeadMiddleware */
 final class ImplicitHeadMiddlewareTest extends TestCase
 {
-    /** @var ResponseInterface&MockObject */
-    private ResponseInterface $response;
-
     /** @var RouterInterface&MockObject */
     private RouterInterface $router;
-
-    /** @var StreamInterface&MockObject */
-    private StreamInterface $stream;
 
     private ImplicitHeadMiddleware $middleware;
 
@@ -34,249 +30,186 @@ final class ImplicitHeadMiddlewareTest extends TestCase
     {
         parent::setUp();
 
-        $this->router = $this->createMock(RouterInterface::class);
-        $this->stream = $this->createMock(StreamInterface::class);
-
-        $streamFactory = fn (): StreamInterface => $this->stream;
-
-        $this->middleware = new ImplicitHeadMiddleware($this->router, $streamFactory);
-        $this->response   = $this->createMock(ResponseInterface::class);
+        $this->router     = $this->createMock(RouterInterface::class);
+        $this->middleware = new ImplicitHeadMiddleware(
+            $this->router,
+            fn (): StreamInterface => $this->createMock(StreamInterface::class),
+        );
     }
 
-    public function testReturnsResultOfHandlerOnNonHeadRequests(): void
+    /** @return array<non-empty-string, array{0: non-empty-string}> */
+    public static function nonHeadMethods(): array
     {
-        $request = $this->createMock(ServerRequestInterface::class);
-        $request
-            ->method('getMethod')
-            ->willReturn(RequestMethod::METHOD_GET);
+        return [
+            RequestMethod::METHOD_GET     => [RequestMethod::METHOD_GET],
+            RequestMethod::METHOD_POST    => [RequestMethod::METHOD_POST],
+            RequestMethod::METHOD_PATCH   => [RequestMethod::METHOD_PATCH],
+            RequestMethod::METHOD_PUT     => [RequestMethod::METHOD_PUT],
+            RequestMethod::METHOD_DELETE  => [RequestMethod::METHOD_DELETE],
+            RequestMethod::METHOD_OPTIONS => [RequestMethod::METHOD_OPTIONS],
+            RequestMethod::METHOD_TRACE   => [RequestMethod::METHOD_TRACE],
+            RequestMethod::METHOD_CONNECT => [RequestMethod::METHOD_CONNECT],
+        ];
+    }
 
-        $handler = $this->createMock(RequestHandlerInterface::class);
-        $handler
-            ->method('handle')
-            ->with($request)
-            ->willReturn($this->response);
+    #[DataProvider('nonHeadMethods')]
+    public function testReturnsResultOfHandlerForNonHeadRequests(string $method): void
+    {
+        $request  = (new ServerRequest())->withMethod($method);
+        $response = new TextResponse('Whatever');
+        $handler  = new RequestHandlerStub($response);
 
         $result = $this->middleware->process($request, $handler);
 
-        self::assertSame($this->response, $result);
+        self::assertTrue($handler->didExecute());
+        self::assertSame($request, $handler->receivedRequest());
+        self::assertSame($response, $result);
     }
 
     public function testReturnsResultOfHandlerWhenNoRouteResultPresentInRequest(): void
     {
-        $request = $this->createMock(ServerRequestInterface::class);
-        $request
-            ->method('getMethod')
-            ->willReturn(RequestMethod::METHOD_HEAD);
-
-        $request
-            ->method('getAttribute')
-            ->with(RouteResult::class)
-            ->willReturn(null);
-
-        $handler = $this->createMock(RequestHandlerInterface::class);
-        $handler
-            ->method('handle')
-            ->with($request)
-            ->willReturn($this->response);
+        $request  = (new ServerRequest())->withMethod(RequestMethod::METHOD_HEAD);
+        $response = new TextResponse('Whatever');
+        $handler  = new RequestHandlerStub($response);
 
         $result = $this->middleware->process($request, $handler);
 
-        self::assertSame($this->response, $result);
+        self::assertTrue($handler->didExecute());
+        self::assertSame($request, $handler->receivedRequest());
+        self::assertSame($response, $result);
+    }
+
+    public function testReturnsResultOfHandlerWhenTheRouteResultMatchesARouteThatSupportsHeadRequests(): void
+    {
+        $route   = new Route('/foo', $this->createMock(MiddlewareInterface::class), [RequestMethod::METHOD_HEAD], 'route-name');
+        $request = (new ServerRequest())
+            ->withMethod(RequestMethod::METHOD_HEAD)
+            ->withAttribute(RouteResult::class, RouteResult::fromRoute($route));
+
+        $response = new TextResponse('Whatever');
+        $handler  = new RequestHandlerStub($response);
+
+        $result = $this->middleware->process($request, $handler);
+
+        self::assertTrue($handler->didExecute());
+        self::assertSame($request, $handler->receivedRequest());
+        self::assertSame($response, $result);
     }
 
     public function testReturnsResultOfHandlerWhenRouteSupportsHeadExplicitly(): void
     {
-        $route  = $this->createMock(Route::class);
-        $result = RouteResult::fromRoute($route);
+        $route   = $this->createMock(Route::class);
+        $result  = RouteResult::fromRoute($route);
+        $request = (new ServerRequest())
+            ->withMethod(RequestMethod::METHOD_HEAD)
+            ->withAttribute(RouteResult::class, $result);
 
-        $request = $this->createMock(ServerRequestInterface::class);
-        $request
-            ->method('getMethod')
-            ->willReturn(RequestMethod::METHOD_HEAD);
-
-        $request
-            ->method('getAttribute')
-            ->with(RouteResult::class)
-            ->willReturn($result);
-
-        $handler = $this->createMock(RequestHandlerInterface::class);
-        $handler
-            ->method('handle')
-            ->with($request)
-            ->willReturn($this->response);
+        $response = new TextResponse('Whatever');
+        $handler  = new RequestHandlerStub($response);
 
         $result = $this->middleware->process($request, $handler);
 
-        self::assertSame($this->response, $result);
+        self::assertTrue($handler->didExecute());
+        self::assertSame($request, $handler->receivedRequest());
+        self::assertSame($response, $result);
     }
 
     public function testReturnsResultOfHandlerWhenRouteDoesNotExplicitlySupportHeadAndDoesNotSupportGet(): void
     {
-        $result = RouteResult::fromRouteFailure([]);
+        $request = (new ServerRequest())
+            ->withMethod(RequestMethod::METHOD_HEAD)
+            ->withAttribute(RouteResult::class, RouteResult::fromRouteFailure([]));
 
-        $request = $this->createMock(ServerRequestInterface::class);
-        $request
-            ->method('getMethod')
-            ->willReturn(RequestMethod::METHOD_HEAD);
-
-        $request
-            ->method('getAttribute')
-            ->with(RouteResult::class)
-            ->willReturn($result);
-
-        $request
-            ->expects(self::once())
-            ->method('withMethod')
-            ->with(RequestMethod::METHOD_GET)
-            ->willReturnSelf();
-
-        $this->router
-            ->expects(self::once())
+        $this->router->expects(self::once())
             ->method('match')
-            ->with($request)
-            ->willReturn($result);
+            ->with(self::callback(static function (ServerRequestInterface $matchInput) use ($request): bool {
+                self::assertNotSame($request, $matchInput);
+                self::assertSame(RequestMethod::METHOD_GET, $matchInput->getMethod());
 
-        $handler = $this->createMock(RequestHandlerInterface::class);
-        $handler
-            ->method('handle')
-            ->with($request)
-            ->willReturn($this->response);
+                return true;
+            }))->willReturn(RouteResult::fromRouteFailure([]));
 
-        $response = $this->middleware->process($request, $handler);
+        $response = new TextResponse('Whatever');
+        $handler  = new RequestHandlerStub($response);
 
-        self::assertSame($this->response, $response);
+        $result = $this->middleware->process($request, $handler);
+
+        self::assertTrue($handler->didExecute());
+        self::assertSame($request, $handler->receivedRequest());
+        self::assertSame($response, $result);
     }
 
     public function testInvokesHandlerWhenRouteImplicitlySupportsHeadAndSupportsGet(): void
     {
-        $result = RouteResult::fromRouteFailure([]);
+        $matchFailure = RouteResult::fromRouteFailure([]);
+        $matchedRoute = new Route('/foo', $this->createMock(MiddlewareInterface::class), [RequestMethod::METHOD_GET], 'route-name');
+        $matchSuccess = RouteResult::fromRoute($matchedRoute);
 
-        $request = $this->createMock(ServerRequestInterface::class);
-        $request
-            ->method('getMethod')
-            ->willReturn(RequestMethod::METHOD_HEAD);
+        $request = (new ServerRequest())
+            ->withMethod(RequestMethod::METHOD_HEAD)
+            ->withAttribute(RouteResult::class, $matchFailure);
 
-        $request
-            ->method('getAttribute')
-            ->with(RouteResult::class)
-            ->willReturn($result);
-
-        $request
-            ->expects(self::exactly(2))
-            ->method('withMethod')
-            ->with(RequestMethod::METHOD_GET)
-            ->willReturnSelf();
-
-        $response = $this->createMock(ResponseInterface::class);
-        $response
-            ->expects(self::once())
-            ->method('withBody')
-            ->with($this->stream)
-            ->willReturnSelf();
-
-        $route  = $this->createMock(Route::class);
-        $result = RouteResult::fromRoute($route);
-
-        $request
-            ->expects(self::exactly(2))
-            ->method('withAttribute')
-            ->withConsecutive(
-                [
-                    RouteResult::class,
-                    $result,
-                ],
-                [
-                    ImplicitHeadMiddleware::FORWARDED_HTTP_METHOD_ATTRIBUTE,
-                    RequestMethod::METHOD_HEAD,
-                ]
-            )
-            ->willReturnSelf();
-
-        $this->router
-            ->expects(self::once())
+        $this->router->expects(self::once())
             ->method('match')
-            ->with($request)
-            ->willReturn($result);
+            ->with(self::callback(static function (ServerRequestInterface $matchInput) use ($request): bool {
+                self::assertNotSame($request, $matchInput);
+                self::assertSame(RequestMethod::METHOD_GET, $matchInput->getMethod());
 
-        $handler = $this->createMock(RequestHandlerInterface::class);
-        $handler
-            ->method('handle')
-            ->with($request)
-            ->willReturn($response);
+                return true;
+            }))->willReturn($matchSuccess);
+
+        $response = new TextResponse('Whatever');
+        $handler  = new RequestHandlerStub($response);
 
         $result = $this->middleware->process($request, $handler);
 
-        self::assertSame($response, $result);
+        self::assertTrue($handler->didExecute());
+        self::assertNotSame($request, $handler->receivedRequest());
+        self::assertNotSame($response, $result);
+
+        self::assertEmpty((string) $result->getBody());
+
+        $received = $handler->receivedRequest();
+        self::assertSame($matchSuccess, $received->getAttribute(RouteResult::class));
+        self::assertSame(RequestMethod::METHOD_HEAD, $received->getAttribute(ImplicitHeadMiddleware::FORWARDED_HTTP_METHOD_ATTRIBUTE));
+        self::assertSame(RequestMethod::METHOD_GET, $received->getMethod());
     }
 
     public function testInvokesHandlerWithRequestComposingRouteResultAndAttributes(): void
     {
-        $result = RouteResult::fromRouteFailure([]);
+        $matchFailure = RouteResult::fromRouteFailure([]);
+        $matchedRoute = new Route('/foo', $this->createMock(MiddlewareInterface::class), [RequestMethod::METHOD_GET], 'route-name');
+        $matchSuccess = RouteResult::fromRoute($matchedRoute, ['foo' => 'bar', 'baz' => 'bat']);
 
-        $request = $this->createMock(ServerRequestInterface::class);
-        $request
-            ->method('getMethod')
-            ->willReturn(RequestMethod::METHOD_HEAD);
+        $request = (new ServerRequest())
+            ->withMethod(RequestMethod::METHOD_HEAD)
+            ->withAttribute(RouteResult::class, $matchFailure);
 
-        $request
-            ->method('getAttribute')
-            ->with(RouteResult::class)
-            ->willReturn($result);
-
-        $request
-            ->expects(self::exactly(2))
-            ->method('withMethod')
-            ->with(RequestMethod::METHOD_GET)
-            ->willReturnSelf();
-
-        $route                     = $this->createMock(Route::class);
-        $resultForRequestMethodGet = RouteResult::fromRoute($route, ['foo' => 'bar', 'baz' => 'bat']);
-
-        $request
-            ->expects(self::exactly(4))
-            ->method('withAttribute')
-            ->withConsecutive(
-                [
-                    'foo',
-                    'bar',
-                ],
-                [
-                    'baz',
-                    'bat',
-                ],
-                [
-                    RouteResult::class,
-                    $resultForRequestMethodGet,
-                ],
-                [
-                    ImplicitHeadMiddleware::FORWARDED_HTTP_METHOD_ATTRIBUTE,
-                    RequestMethod::METHOD_HEAD,
-                ]
-            )
-            ->willReturnSelf();
-
-        $response = $this->createMock(ResponseInterface::class);
-        $response
-            ->expects(self::once())
-            ->method('withBody')
-            ->with($this->stream)
-            ->willReturnSelf();
-
-        $this->router
-            ->expects(self::once())
+        $this->router->expects(self::once())
             ->method('match')
-            ->with($request)
-            ->willReturn($resultForRequestMethodGet);
+            ->with(self::callback(static function (ServerRequestInterface $matchInput) use ($request): bool {
+                self::assertNotSame($request, $matchInput);
+                self::assertSame(RequestMethod::METHOD_GET, $matchInput->getMethod());
 
-        $handler = $this->createMock(RequestHandlerInterface::class);
-        $handler
-            ->expects(self::once())
-            ->method('handle')
-            ->with($request)
-            ->willReturn($response);
+                return true;
+            }))->willReturn($matchSuccess);
+
+        $response = new TextResponse('Whatever');
+        $handler  = new RequestHandlerStub($response);
 
         $result = $this->middleware->process($request, $handler);
 
-        self::assertSame($response, $result);
+        self::assertTrue($handler->didExecute());
+        self::assertNotSame($request, $handler->receivedRequest());
+        self::assertNotSame($response, $result);
+
+        self::assertEmpty((string) $result->getBody());
+
+        $received = $handler->receivedRequest();
+        self::assertSame($matchSuccess, $received->getAttribute(RouteResult::class));
+        self::assertSame(RequestMethod::METHOD_HEAD, $received->getAttribute(ImplicitHeadMiddleware::FORWARDED_HTTP_METHOD_ATTRIBUTE));
+        self::assertSame(RequestMethod::METHOD_GET, $received->getMethod());
+        self::assertSame('bar', $received->getAttribute('foo'));
+        self::assertSame('bat', $received->getAttribute('baz'));
     }
 }

--- a/test/Middleware/ImplicitHeadMiddlewareTest.php
+++ b/test/Middleware/ImplicitHeadMiddlewareTest.php
@@ -81,7 +81,12 @@ final class ImplicitHeadMiddlewareTest extends TestCase
 
     public function testReturnsResultOfHandlerWhenTheRouteResultMatchesARouteThatSupportsHeadRequests(): void
     {
-        $route   = new Route('/foo', $this->createMock(MiddlewareInterface::class), [RequestMethod::METHOD_HEAD], 'route-name');
+        $route   = new Route(
+            '/foo',
+            $this->createMock(MiddlewareInterface::class),
+            [RequestMethod::METHOD_HEAD],
+            'route-name',
+        );
         $request = (new ServerRequest())
             ->withMethod(RequestMethod::METHOD_HEAD)
             ->withAttribute(RouteResult::class, RouteResult::fromRoute($route));
@@ -142,7 +147,12 @@ final class ImplicitHeadMiddlewareTest extends TestCase
     public function testInvokesHandlerWhenRouteImplicitlySupportsHeadAndSupportsGet(): void
     {
         $matchFailure = RouteResult::fromRouteFailure([]);
-        $matchedRoute = new Route('/foo', $this->createMock(MiddlewareInterface::class), [RequestMethod::METHOD_GET], 'route-name');
+        $matchedRoute = new Route(
+            '/foo',
+            $this->createMock(MiddlewareInterface::class),
+            [RequestMethod::METHOD_GET],
+            'route-name',
+        );
         $matchSuccess = RouteResult::fromRoute($matchedRoute);
 
         $request = (new ServerRequest())
@@ -171,14 +181,22 @@ final class ImplicitHeadMiddlewareTest extends TestCase
 
         $received = $handler->receivedRequest();
         self::assertSame($matchSuccess, $received->getAttribute(RouteResult::class));
-        self::assertSame(RequestMethod::METHOD_HEAD, $received->getAttribute(ImplicitHeadMiddleware::FORWARDED_HTTP_METHOD_ATTRIBUTE));
+        self::assertSame(
+            RequestMethod::METHOD_HEAD,
+            $received->getAttribute(ImplicitHeadMiddleware::FORWARDED_HTTP_METHOD_ATTRIBUTE),
+        );
         self::assertSame(RequestMethod::METHOD_GET, $received->getMethod());
     }
 
     public function testInvokesHandlerWithRequestComposingRouteResultAndAttributes(): void
     {
         $matchFailure = RouteResult::fromRouteFailure([]);
-        $matchedRoute = new Route('/foo', $this->createMock(MiddlewareInterface::class), [RequestMethod::METHOD_GET], 'route-name');
+        $matchedRoute = new Route(
+            '/foo',
+            $this->createMock(MiddlewareInterface::class),
+            [RequestMethod::METHOD_GET],
+            'route-name',
+        );
         $matchSuccess = RouteResult::fromRoute($matchedRoute, ['foo' => 'bar', 'baz' => 'bat']);
 
         $request = (new ServerRequest())
@@ -207,7 +225,10 @@ final class ImplicitHeadMiddlewareTest extends TestCase
 
         $received = $handler->receivedRequest();
         self::assertSame($matchSuccess, $received->getAttribute(RouteResult::class));
-        self::assertSame(RequestMethod::METHOD_HEAD, $received->getAttribute(ImplicitHeadMiddleware::FORWARDED_HTTP_METHOD_ATTRIBUTE));
+        self::assertSame(
+            RequestMethod::METHOD_HEAD,
+            $received->getAttribute(ImplicitHeadMiddleware::FORWARDED_HTTP_METHOD_ATTRIBUTE),
+        );
         self::assertSame(RequestMethod::METHOD_GET, $received->getMethod());
         self::assertSame('bar', $received->getAttribute('foo'));
         self::assertSame('bat', $received->getAttribute('baz'));

--- a/test/Middleware/ImplicitOptionsMiddlewareFactoryTest.php
+++ b/test/Middleware/ImplicitOptionsMiddlewareFactoryTest.php
@@ -6,13 +6,14 @@ namespace MezzioTest\Router\Middleware;
 
 use Mezzio\Router\Exception\MissingDependencyException;
 use Mezzio\Router\Middleware\ImplicitOptionsMiddlewareFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 
-/** @covers \Mezzio\Router\Middleware\ImplicitOptionsMiddlewareFactory */
+#[CoversClass(ImplicitOptionsMiddlewareFactory::class)]
 final class ImplicitOptionsMiddlewareFactoryTest extends TestCase
 {
     /** @var ContainerInterface&MockObject */
@@ -42,8 +43,14 @@ final class ImplicitOptionsMiddlewareFactoryTest extends TestCase
 
         $this->container
             ->method('has')
-            ->withConsecutive([ResponseFactoryInterface::class], [ResponseInterface::class])
-            ->willReturnOnConsecutiveCalls(false, true);
+            ->with(self::callback(static function ($arg): bool {
+                self::assertContains($arg, [
+                    ResponseFactoryInterface::class,
+                    ResponseInterface::class,
+                ]);
+
+                return true;
+            }))->willReturnOnConsecutiveCalls(false, true);
 
         $this->container
             ->expects(self::once())

--- a/test/Middleware/MethodNotAllowedMiddlewareFactoryTest.php
+++ b/test/Middleware/MethodNotAllowedMiddlewareFactoryTest.php
@@ -17,6 +17,8 @@ use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 
+use function in_array;
+
 #[CoversClass(MethodNotAllowedMiddlewareFactory::class)]
 final class MethodNotAllowedMiddlewareFactoryTest extends TestCase
 {
@@ -46,7 +48,7 @@ final class MethodNotAllowedMiddlewareFactoryTest extends TestCase
                 'dependencies' => [
                     'factories' => [
                         ResponseInterface::class => function (): ResponseInterface {
-                            return $this->createMock(ResponseInterface::class);
+                            return self::$responseMock;
                         },
                     ],
                 ],
@@ -68,7 +70,7 @@ final class MethodNotAllowedMiddlewareFactoryTest extends TestCase
                 'dependencies' => [
                     'delegators' => [
                         ResponseInterface::class => [
-                            fn (): ResponseInterface => $this->createMock(ResponseInterface::class),
+                            fn (): ResponseInterface => self::$responseMock,
                         ],
                     ],
                 ],
@@ -119,8 +121,7 @@ final class MethodNotAllowedMiddlewareFactoryTest extends TestCase
 
     public function testWillUseResponseFactoryInterfaceFromContainerWhenApplicationFactoryIsNotOverridden(): void
     {
-        $responseFactory = $this->createMock(ResponseFactoryInterface::class);
-        $container       = new InMemoryContainer();
+        $container = new InMemoryContainer();
         $container->set('config', [
             'dependencies' => [
                 'factories' => [
@@ -128,10 +129,10 @@ final class MethodNotAllowedMiddlewareFactoryTest extends TestCase
                 ],
             ],
         ]);
-        $container->set(ResponseFactoryInterface::class, $responseFactory);
+        $container->set(ResponseFactoryInterface::class, self::$responseFactoryMock);
         $middleware = ($this->factory)($container);
 
-        self::assertSame($responseFactory, $middleware->getResponseFactory());
+        self::assertSame(self::$responseFactoryMock, $middleware->getResponseFactory());
     }
 
     /** @param array<string,mixed> $config */

--- a/test/Middleware/MethodNotAllowedMiddlewareFactoryTest.php
+++ b/test/Middleware/MethodNotAllowedMiddlewareFactoryTest.php
@@ -9,18 +9,20 @@ use Mezzio\Router\Exception\MissingDependencyException;
 use Mezzio\Router\Middleware\MethodNotAllowedMiddlewareFactory;
 use Mezzio\Router\Response\CallableResponseFactoryDecorator;
 use MezzioTest\Router\InMemoryContainer;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 
-/** @covers \Mezzio\Router\Middleware\MethodNotAllowedMiddlewareFactory */
+#[CoversClass(MethodNotAllowedMiddlewareFactory::class)]
 final class MethodNotAllowedMiddlewareFactoryTest extends TestCase
 {
-    /** @var ContainerInterface&MockObject */
-    private ContainerInterface $container;
-
+    private static ResponseFactoryInterface&MockObject $responseFactoryMock;
+    private static ResponseInterface&MockObject $responseMock;
+    private ContainerInterface&MockObject $container;
     private MethodNotAllowedMiddlewareFactory $factory;
 
     protected function setUp(): void
@@ -29,12 +31,15 @@ final class MethodNotAllowedMiddlewareFactoryTest extends TestCase
 
         $this->container = $this->createMock(ContainerInterface::class);
         $this->factory   = new MethodNotAllowedMiddlewareFactory();
+
+        self::$responseFactoryMock = $this->createMock(ResponseFactoryInterface::class);
+        self::$responseMock        = $this->createMock(ResponseInterface::class);
     }
 
     /**
      * @psalm-return Generator<non-empty-string,array{0:array<string,mixed>}>
      */
-    public function configurationsWithOverriddenResponseInterfaceFactory(): Generator
+    public static function configurationsWithOverriddenResponseInterfaceFactory(): Generator
     {
         yield 'default' => [
             [
@@ -75,8 +80,12 @@ final class MethodNotAllowedMiddlewareFactoryTest extends TestCase
     {
         $this->container
             ->method('has')
-            ->withConsecutive([ResponseFactoryInterface::class], [ResponseInterface::class])
-            ->willReturn(false);
+            ->with(self::callback(static function ($arg): bool {
+                return in_array($arg, [
+                    ResponseFactoryInterface::class,
+                    ResponseInterface::class,
+                ], true);
+            }))->willReturn(false);
 
         $this->expectException(MissingDependencyException::class);
 
@@ -91,7 +100,12 @@ final class MethodNotAllowedMiddlewareFactoryTest extends TestCase
         $this->container
             ->expects(self::exactly(2))
             ->method('has')
-            ->withConsecutive([ResponseFactoryInterface::class], [ResponseInterface::class])
+            ->with(self::callback(static function ($arg): bool {
+                return in_array($arg, [
+                    ResponseFactoryInterface::class,
+                    ResponseInterface::class,
+                ], true);
+            }))
             ->willReturn(false, true);
 
         $this->container
@@ -120,25 +134,21 @@ final class MethodNotAllowedMiddlewareFactoryTest extends TestCase
         self::assertSame($responseFactory, $middleware->getResponseFactory());
     }
 
-    /**
-     * @param array<string,mixed> $config
-     * @dataProvider configurationsWithOverriddenResponseInterfaceFactory
-     */
+    /** @param array<string,mixed> $config */
+    #[DataProvider('configurationsWithOverriddenResponseInterfaceFactory')]
     public function testWontUseResponseFactoryInterfaceFromContainerWhenApplicationFactoryIsOverriden(
         array $config
     ): void {
-        $responseFactory = $this->createMock(ResponseFactoryInterface::class);
-        $container       = new InMemoryContainer();
+        $container = new InMemoryContainer();
         $container->set('config', $config);
-        $container->set(ResponseFactoryInterface::class, $responseFactory);
-        $response = $this->createMock(ResponseInterface::class);
-        $container->set(ResponseInterface::class, static fn (): ResponseInterface => $response);
+        $container->set(ResponseFactoryInterface::class, self::$responseFactoryMock);
+        $container->set(ResponseInterface::class, static fn (): ResponseInterface => self::$responseMock);
 
         $middleware                   = ($this->factory)($container);
         $responseFactoryFromGenerator = $middleware->getResponseFactory();
 
-        self::assertNotSame($responseFactory, $responseFactoryFromGenerator);
+        self::assertNotSame(self::$responseFactoryMock, $responseFactoryFromGenerator);
         self::assertInstanceOf(CallableResponseFactoryDecorator::class, $responseFactoryFromGenerator);
-        self::assertSame($response, $responseFactoryFromGenerator->getResponseFromCallable());
+        self::assertSame(self::$responseMock, $responseFactoryFromGenerator->getResponseFromCallable());
     }
 }

--- a/test/Middleware/RequestHandlerStub.php
+++ b/test/Middleware/RequestHandlerStub.php
@@ -18,6 +18,7 @@ final class RequestHandlerStub implements RequestHandlerInterface
     public function __construct(ResponseInterface|null $response = null)
     {
         $this->response = $response ?: new TextResponse('Default Response');
+        $this->received = null;
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface

--- a/test/Middleware/RequestHandlerStub.php
+++ b/test/Middleware/RequestHandlerStub.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MezzioTest\Router\Middleware;
+
+use BadMethodCallException;
+use Laminas\Diactoros\Response\TextResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class RequestHandlerStub implements RequestHandlerInterface
+{
+    private ServerRequestInterface|null $received;
+    private ResponseInterface $response;
+
+    public function __construct(ResponseInterface|null $response = null)
+    {
+        $this->response = $response ?: new TextResponse('Default Response');
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $this->received = $request;
+
+        return $this->response;
+    }
+
+    public function didExecute(): bool
+    {
+        return $this->received !== null;
+    }
+
+    public function receivedRequest(): ServerRequestInterface
+    {
+        if (! $this->received) {
+            throw new BadMethodCallException('A request has not yet been received');
+        }
+
+        return $this->received;
+    }
+}

--- a/test/Middleware/RouteMiddlewareTest.php
+++ b/test/Middleware/RouteMiddlewareTest.php
@@ -4,143 +4,98 @@ declare(strict_types=1);
 
 namespace MezzioTest\Router\Middleware;
 
+use Laminas\Diactoros\Response\TextResponse;
+use Laminas\Diactoros\ServerRequest;
 use Mezzio\Router\Middleware\RouteMiddleware;
 use Mezzio\Router\Route;
 use Mezzio\Router\RouteResult;
 use Mezzio\Router\RouterInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
-use Psr\Http\Server\RequestHandlerInterface;
 
-/** @covers \Mezzio\Router\Middleware\RouteMiddleware */
+#[CoversClass(RouteMiddleware::class)]
 final class RouteMiddlewareTest extends TestCase
 {
-    /** @var RouterInterface&MockObject */
-    private RouterInterface $router;
-
-    /** @var ResponseInterface&MockObject */
-    private ResponseInterface $response;
-
-    /** @var ServerRequestInterface&MockObject */
-    private ServerRequestInterface $request;
-
-    /** @var RequestHandlerInterface&MockObject */
-    private RequestHandlerInterface $handler;
-
+    private RouterInterface&MockObject $router;
     private RouteMiddleware $middleware;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->router   = $this->createMock(RouterInterface::class);
-        $this->request  = $this->createMock(ServerRequestInterface::class);
-        $this->response = $this->createMock(ResponseInterface::class);
-        $this->handler  = $this->createMock(RequestHandlerInterface::class);
-
+        $this->router     = $this->createMock(RouterInterface::class);
         $this->middleware = new RouteMiddleware($this->router);
     }
 
     public function testRoutingFailureDueToHttpMethodCallsHandlerWithRequestComposingRouteResult(): void
     {
-        $result = RouteResult::fromRouteFailure(['GET', 'POST']);
+        $result   = RouteResult::fromRouteFailure(['GET', 'POST']);
+        $response = new TextResponse('Whatever');
+        $handler  = new RequestHandlerStub($response);
+        $request  = new ServerRequest();
 
         $this->router
             ->method('match')
-            ->with($this->request)
+            ->with($request)
             ->willReturn($result);
 
-        $this->handler
-            ->method('handle')
-            ->with($this->request)
-            ->willReturn($this->response);
-
-        $this->request
-            ->expects(self::once())
-            ->method('withAttribute')
-            ->withConsecutive(
-                [
-                    RouteResult::class,
-                    $result,
-                ]
-            )->willReturnSelf();
-
-        $response = $this->middleware->process($this->request, $this->handler);
-
-        self::assertSame($this->response, $response);
+        self::assertSame($response, $this->middleware->process($request, $handler));
+        self::assertTrue($handler->didExecute());
+        $received = $handler->receivedRequest();
+        self::assertNotSame($request, $received);
+        self::assertSame($result, $received->getAttribute(RouteResult::class));
     }
 
     public function testGeneralRoutingFailureInvokesHandlerWithRequestComposingRouteResult(): void
     {
         $result = RouteResult::fromRouteFailure(null);
 
+        $response = new TextResponse('Whatever');
+        $handler  = new RequestHandlerStub($response);
+        $request  = new ServerRequest();
+
         $this->router
             ->method('match')
-            ->with($this->request)
+            ->with($request)
             ->willReturn($result);
 
-        $this->handler
-            ->method('handle')
-            ->with($this->request)
-            ->willReturn($this->response);
-
-        $this->request
-            ->expects(self::exactly(1))
-            ->method('withAttribute')
-            ->withConsecutive(
-                [
-                    RouteResult::class,
-                    $result,
-                ]
-            )->willReturnSelf();
-
-        $response = $this->middleware->process($this->request, $this->handler);
-
-        self::assertSame($this->response, $response);
+        self::assertSame($response, $this->middleware->process($request, $handler));
+        self::assertTrue($handler->didExecute());
+        $received = $handler->receivedRequest();
+        self::assertNotSame($request, $received);
+        self::assertSame($result, $received->getAttribute(RouteResult::class));
     }
 
     public function testRoutingSuccessInvokesHandlerWithRequestComposingRouteResultAndAttributes(): void
     {
-        $middleware = $this->createMock(MiddlewareInterface::class);
-        $result     = RouteResult::fromRoute(
-            new Route('/foo', $middleware),
-            ['foo' => 'bar', 'baz' => 'bat']
+        $result = RouteResult::fromRoute(
+            new Route(
+                '/foo',
+                $this->createMock(MiddlewareInterface::class)
+            ),
+            ['foo' => 'bar', 'baz' => 'bat'],
         );
+
+        $response = new TextResponse('Whatever');
+        $handler  = new RequestHandlerStub($response);
+        $request  = new ServerRequest();
 
         $this->router
             ->expects(self::once())
             ->method('match')
-            ->with($this->request)
+            ->with($request)
             ->willReturn($result);
 
-        $this->request
-            ->expects(self::exactly(3))
-            ->method('withAttribute')
-            ->withConsecutive(
-                [
-                    RouteResult::class,
-                    $result,
-                ],
-                [
-                    'foo',
-                    'bar',
-                ],
-                [
-                    'baz',
-                    'bat',
-                ]
-            )->willReturnSelf();
-
-        $this->handler
-            ->method('handle')
-            ->with($this->request)
-            ->willReturn($this->response);
-
-        $response = $this->middleware->process($this->request, $this->handler);
-
-        self::assertSame($this->response, $response);
+        self::assertSame(
+            $response,
+            $this->middleware->process($request, $handler),
+        );
+        self::assertTrue($handler->didExecute());
+        $received = $handler->receivedRequest();
+        self::assertNotSame($request, $received);
+        self::assertSame('bar', $received->getAttribute('foo'));
+        self::assertSame('bat', $received->getAttribute('baz'));
     }
 }

--- a/test/RouteCollectorTest.php
+++ b/test/RouteCollectorTest.php
@@ -107,7 +107,6 @@ final class RouteCollectorTest extends TestCase
         self::assertSame(Route::HTTP_METHOD_ANY, $route->getAllowedMethods());
     }
 
-    /** @param string $method */
     #[DataProvider('commonHttpMethods')]
     public function testCanCallRouteWithHttpMethods(string $method): void
     {

--- a/test/RouteCollectorTest.php
+++ b/test/RouteCollectorTest.php
@@ -9,6 +9,8 @@ use Mezzio\Router\Exception;
 use Mezzio\Router\Route;
 use Mezzio\Router\RouteCollector;
 use Mezzio\Router\RouterInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
@@ -22,7 +24,7 @@ use function microtime;
 use function range;
 use function sprintf;
 
-/** @covers \Mezzio\Router\RouteCollector */
+#[CoversClass(RouteCollector::class)]
 final class RouteCollectorTest extends TestCase
 {
     /** @var RouterInterface&MockObject */
@@ -67,7 +69,7 @@ final class RouteCollectorTest extends TestCase
     /**
      * @return array<non-empty-string, array{0:non-empty-string}>
      */
-    public function commonHttpMethods(): array
+    public static function commonHttpMethods(): array
     {
         return [
             RequestMethod::METHOD_GET    => [RequestMethod::METHOD_GET],
@@ -105,11 +107,9 @@ final class RouteCollectorTest extends TestCase
         self::assertSame(Route::HTTP_METHOD_ANY, $route->getAllowedMethods());
     }
 
-    /**
-     * @dataProvider commonHttpMethods
-     * @param string $method
-     */
-    public function testCanCallRouteWithHttpMethods($method): void
+    /** @param string $method */
+    #[DataProvider('commonHttpMethods')]
+    public function testCanCallRouteWithHttpMethods(string $method): void
     {
         $this->router
             ->expects(self::once())
@@ -156,7 +156,7 @@ final class RouteCollectorTest extends TestCase
     /**
      * @return array<string, array{0: mixed}>
      */
-    public function invalidPathTypes(): array
+    public static function invalidPathTypes(): array
     {
         return [
             'null'       => [null],
@@ -171,9 +171,7 @@ final class RouteCollectorTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider invalidPathTypes
-     */
+    #[DataProvider('invalidPathTypes')]
     public function testCallingRouteWithAnInvalidPathTypeRaisesAnException(mixed $path): void
     {
         $this->expectException(TypeError::class);
@@ -182,10 +180,8 @@ final class RouteCollectorTest extends TestCase
         $this->collector->route($path, $this->createNoopMiddleware());
     }
 
-    /**
-     * @dataProvider commonHttpMethods
-     * @param non-empty-string $method
-     */
+    /** @param non-empty-string $method */
+    #[DataProvider('commonHttpMethods')]
     public function testCommonHttpMethodsAreExposedAsClassMethodsAndReturnRoutes(string $method): void
     {
         $route = $this->collector->{$method}('/foo', $this->noopMiddleware);

--- a/test/RouteTest.php
+++ b/test/RouteTest.php
@@ -7,6 +7,8 @@ namespace MezzioTest\Router;
 use Fig\Http\Message\RequestMethodInterface as RequestMethod;
 use Mezzio\Router\Exception\InvalidArgumentException;
 use Mezzio\Router\Route;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
@@ -14,7 +16,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
-/** @covers \Mezzio\Router\Route */
+#[CoversClass(Route::class)]
 final class RouteTest extends TestCase
 {
     /** @var MiddlewareInterface&MockObject */
@@ -136,7 +138,7 @@ final class RouteTest extends TestCase
     /**
      * @return array<array-key, array{0: list<mixed>}>
      */
-    public function invalidHttpMethodsProvider(): array
+    public static function invalidHttpMethodsProvider(): array
     {
         return [
             [[123]],
@@ -146,10 +148,8 @@ final class RouteTest extends TestCase
         ];
     }
 
-    /**
-     * @param list<mixed> $invalidHttpMethods
-     * @dataProvider invalidHttpMethodsProvider
-     */
+    /** @param list<mixed> $invalidHttpMethods */
+    #[DataProvider('invalidHttpMethodsProvider')]
     public function testThrowsExceptionIfInvalidHttpMethodsAreProvided(array $invalidHttpMethods): void
     {
         $this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| BC Break      | yes
| QA            | yes

### Description

General reduction in mocking helps with the removal of `withConsecutive` in `MockObject`.

The BC break here relates to the [signature change](https://github.com/mezzio/mezzio-router/pull/44/commits/7e883d4c2fe36cf8e4c1ea75246b82e7e297415c) of the abstract data provider method.

Closes #41