### PR TITLE
Allow retrieval of `RouteCollectorInterface` from the container

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,10 +50,11 @@
     "require-dev": {
         "laminas/laminas-coding-standard": "~2.5.0",
         "laminas/laminas-diactoros": "^2.24",
+        "laminas/laminas-servicemanager": "^3.20.0",
         "laminas/laminas-stratigility": "^3.9.0",
-        "phpunit/phpunit": "^10.0.12",
+        "phpunit/phpunit": "^10.0.19",
         "psalm/plugin-phpunit": "^0.18.4",
-        "vimeo/psalm": "^5.7.7"
+        "vimeo/psalm": "^5.8"
     },
     "suggest": {
         "mezzio/mezzio-aurarouter": "^3.0 to use the Aura.Router routing adapter",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e863b80600da70eea09bd2abc454ef16",
+    "content-hash": "0b5246607f3de246835403a5017e54db",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -64,27 +64,22 @@
         },
         {
             "name": "psr/container",
-            "version": "2.0.2",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
-                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.4.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Psr\\Container\\": "src/"
@@ -111,9 +106,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/2.0.2"
+                "source": "https://github.com/php-fig/container/tree/1.1.2"
             },
-            "time": "2021-11-05T16:47:00+00:00"
+            "time": "2021-11-05T16:50:12+00:00"
         },
         {
             "name": "psr/http-factory",
@@ -1344,6 +1339,155 @@
             "time": "2022-10-10T10:11:09+00:00"
         },
         {
+            "name": "laminas/laminas-servicemanager",
+            "version": "3.20.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-servicemanager.git",
+                "reference": "bc2c2cbe2dd90db8b9d16b0618f542692b76ab59"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/bc2c2cbe2dd90db8b9d16b0618f542692b76ab59",
+                "reference": "bc2c2cbe2dd90db8b9d16b0618f542692b76ab59",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-stdlib": "^3.2.1",
+                "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
+                "psr/container": "^1.0"
+            },
+            "conflict": {
+                "ext-psr": "*",
+                "laminas/laminas-code": "<3.3.1",
+                "zendframework/zend-code": "<3.3.1",
+                "zendframework/zend-servicemanager": "*"
+            },
+            "provide": {
+                "psr/container-implementation": "^1.0"
+            },
+            "replace": {
+                "container-interop/container-interop": "^1.2.0"
+            },
+            "require-dev": {
+                "composer/package-versions-deprecated": "^1.11.99.5",
+                "laminas/laminas-coding-standard": "~2.4.0",
+                "laminas/laminas-container-config-test": "^0.8",
+                "laminas/laminas-dependency-plugin": "^2.2",
+                "mikey179/vfsstream": "^1.6.11@alpha",
+                "ocramius/proxy-manager": "^2.14.1",
+                "phpbench/phpbench": "^1.2.7",
+                "phpunit/phpunit": "^9.5.26",
+                "psalm/plugin-phpunit": "^0.18.0",
+                "vimeo/psalm": "^5.0.0"
+            },
+            "suggest": {
+                "ocramius/proxy-manager": "ProxyManager ^2.1.1 to handle lazy initialization of services"
+            },
+            "bin": [
+                "bin/generate-deps-for-config-factory",
+                "bin/generate-factory-for-class"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/autoload.php"
+                ],
+                "psr-4": {
+                    "Laminas\\ServiceManager\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Factory-Driven Dependency Injection Container",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "PSR-11",
+                "dependency-injection",
+                "di",
+                "dic",
+                "laminas",
+                "service-manager",
+                "servicemanager"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-servicemanager/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-servicemanager/issues",
+                "rss": "https://github.com/laminas/laminas-servicemanager/releases.atom",
+                "source": "https://github.com/laminas/laminas-servicemanager"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2022-12-01T17:03:38+00:00"
+        },
+        {
+            "name": "laminas/laminas-stdlib",
+            "version": "3.17.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-stdlib.git",
+                "reference": "dd35c868075bad80b6718959740913e178eb4274"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/dd35c868075bad80b6718959740913e178eb4274",
+                "reference": "dd35c868075bad80b6718959740913e178eb4274",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~8.1.0 || ~8.2.0"
+            },
+            "conflict": {
+                "zendframework/zend-stdlib": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "^2.5",
+                "phpbench/phpbench": "^1.2.9",
+                "phpunit/phpunit": "^10.0.16",
+                "psalm/plugin-phpunit": "^0.18.4",
+                "vimeo/psalm": "^5.8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Stdlib\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "SPL extensions, array utilities, error handlers, and more",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "stdlib"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-stdlib/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-stdlib/issues",
+                "rss": "https://github.com/laminas/laminas-stdlib/releases.atom",
+                "source": "https://github.com/laminas/laminas-stdlib"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2023-03-20T13:51:37+00:00"
+        },
+        {
             "name": "laminas/laminas-stratigility",
             "version": "3.9.0",
             "source": {
@@ -2229,16 +2373,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.0.18",
+            "version": "10.0.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "582563ed2edc62d1455cdbe00ea49fe09428eef3"
+                "reference": "20c23e85c86e5c06d63538ba464e8054f4744e62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/582563ed2edc62d1455cdbe00ea49fe09428eef3",
-                "reference": "582563ed2edc62d1455cdbe00ea49fe09428eef3",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/20c23e85c86e5c06d63538ba464e8054f4744e62",
+                "reference": "20c23e85c86e5c06d63538ba464e8054f4744e62",
                 "shasum": ""
             },
             "require": {
@@ -2310,7 +2454,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.0.18"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.0.19"
             },
             "funding": [
                 {
@@ -2326,7 +2470,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-22T06:15:31+00:00"
+            "time": "2023-03-27T11:46:33+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -2740,16 +2884,16 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "5.0.0",
+            "version": "5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "70dd1b20bc198da394ad542e988381b44e64e39f"
+                "reference": "aae9a0a43bff37bd5d8d0311426c87bf36153f02"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/70dd1b20bc198da394ad542e988381b44e64e39f",
-                "reference": "70dd1b20bc198da394ad542e988381b44e64e39f",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/aae9a0a43bff37bd5d8d0311426c87bf36153f02",
+                "reference": "aae9a0a43bff37bd5d8d0311426c87bf36153f02",
                 "shasum": ""
             },
             "require": {
@@ -2794,7 +2938,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/5.0.0"
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/5.0.1"
             },
             "funding": [
                 {
@@ -2802,7 +2947,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:00:31+00:00"
+            "time": "2023-03-23T05:12:41+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -4085,21 +4230,22 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.2.1",
+            "version": "v2.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "a8c9cedf55f314f3a186041d19537303766df09a"
+                "reference": "4b426aac47d6427cc1a1d0f7e2ac724627f5966c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/a8c9cedf55f314f3a186041d19537303766df09a",
-                "reference": "a8c9cedf55f314f3a186041d19537303766df09a",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/4b426aac47d6427cc1a1d0f7e2ac724627f5966c",
+                "reference": "4b426aac47d6427cc1a1d0f7e2ac724627f5966c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
-                "psr/container": "^2.0"
+                "php": ">=7.2.5",
+                "psr/container": "^1.1",
+                "symfony/deprecation-contracts": "^2.1|^3"
             },
             "conflict": {
                 "ext-psr": "<1.1|>=2"
@@ -4110,7 +4256,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.3-dev"
+                    "dev-main": "2.5-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -4120,10 +4266,7 @@
             "autoload": {
                 "psr-4": {
                     "Symfony\\Contracts\\Service\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Test/"
-                ]
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -4150,7 +4293,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.2.1"
+                "source": "https://github.com/symfony/service-contracts/tree/v2.5.2"
             },
             "funding": [
                 {
@@ -4166,7 +4309,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-01T10:32:47+00:00"
+            "time": "2022-05-30T19:17:29+00:00"
         },
         {
             "name": "symfony/string",

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace Mezzio\Router;
 
 /**
- * @psalm-type DependencyConfig = array{factories: array<class-string, class-string>}
+ * @psalm-type DependencyConfig = array{
+ *     factories: array<class-string, class-string>,
+ *     aliases?: array<class-string, class-string>,
+ * }
  */
 class ConfigProvider
 {
@@ -28,6 +31,9 @@ class ConfigProvider
                 Middleware\MethodNotAllowedMiddleware::class => Middleware\MethodNotAllowedMiddlewareFactory::class,
                 Middleware\RouteMiddleware::class            => Middleware\RouteMiddlewareFactory::class,
                 RouteCollector::class                        => RouteCollectorFactory::class,
+            ],
+            'aliases'   => [
+                RouteCollectorInterface::class => RouteCollector::class,
             ],
         ];
     }

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -8,6 +8,7 @@ use Mezzio\Router\ConfigProvider;
 use Mezzio\Router\Middleware;
 use Mezzio\Router\RouteCollector;
 use Mezzio\Router\RouteCollectorFactory;
+use Mezzio\Router\RouteCollectorInterface;
 use PHPUnit\Framework\TestCase;
 
 /** @covers \Mezzio\Router\ConfigProvider */
@@ -26,6 +27,9 @@ final class ConfigProviderTest extends TestCase
                     Middleware\MethodNotAllowedMiddleware::class => Middleware\MethodNotAllowedMiddlewareFactory::class,
                     Middleware\RouteMiddleware::class            => Middleware\RouteMiddlewareFactory::class,
                     RouteCollector::class                        => RouteCollectorFactory::class,
+                ],
+                'aliases'   => [
+                    RouteCollectorInterface::class => RouteCollector::class,
                 ],
             ],
         ], $provider());

--- a/test/ServiceManagerIntegrationTest.php
+++ b/test/ServiceManagerIntegrationTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MezzioTest\Router;
+
+use Laminas\ServiceManager\ConfigInterface;
+use Laminas\ServiceManager\ServiceManager;
+use Mezzio\Router;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\StreamInterface;
+
+use function array_merge_recursive;
+
+/** @psalm-import-type ServiceManagerConfigurationType from ConfigInterface */
+final class ServiceManagerIntegrationTest extends TestCase
+{
+    private ContainerInterface $container;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        /** @psalm-var ServiceManagerConfigurationType $config */
+        $config          = array_merge_recursive(
+            (new Router\ConfigProvider())->getDependencies(),
+            [
+                'factories' => [
+                    ResponseFactoryInterface::class => function (): ResponseFactoryInterface {
+                        return $this->createMock(ResponseFactoryInterface::class);
+                    },
+                    Router\RouterInterface::class   => function (): Router\RouterInterface {
+                        return $this->createMock(Router\RouterInterface::class);
+                    },
+                    StreamInterface::class          => function (): callable {
+                        return fn (): StreamInterface => $this->createMock(StreamInterface::class);
+                    },
+                ],
+            ],
+        );
+        $this->container = new ServiceManager($config);
+    }
+
+    /**
+     * A list of container ids that should resolve to the expected type
+     *
+     * @return array<array-key, array{0: class-string, 1: class-string}>
+     */
+    public static function factories(): array
+    {
+        return [
+            [Router\Middleware\DispatchMiddleware::class, Router\Middleware\DispatchMiddleware::class],
+            [Router\Middleware\ImplicitHeadMiddleware::class, Router\Middleware\ImplicitHeadMiddleware::class],
+            [Router\Middleware\ImplicitOptionsMiddleware::class, Router\Middleware\ImplicitOptionsMiddleware::class],
+            [Router\Middleware\MethodNotAllowedMiddleware::class, Router\Middleware\MethodNotAllowedMiddleware::class],
+            [Router\Middleware\RouteMiddleware::class, Router\Middleware\RouteMiddleware::class],
+            [Router\RouteCollector::class, Router\RouteCollector::class],
+        ];
+    }
+
+    /**
+     * A list of container ids that should resolve to the expected type
+     *
+     * @return array<array-key, array{0: class-string, 1: class-string}>
+     */
+    public static function aliases(): array
+    {
+        return [
+            [Router\RouteCollectorInterface::class, Router\RouteCollectorInterface::class],
+        ];
+    }
+
+    /**
+     * @param class-string $id
+     * @param class-string $expectedType
+     */
+    #[DataProvider('factories')]
+    public function testFactoryIdentifiersCanBeRetrievedFromTheContainer(string $id, string $expectedType): void
+    {
+        self::assertTrue($this->container->has($id));
+        $instance = $this->container->get($id);
+        self::assertInstanceOf($expectedType, $instance);
+    }
+
+    /**
+     * @param class-string $id
+     * @param class-string $expectedType
+     */
+    #[DataProvider('aliases')]
+    public function testAliasesCanBeRetrievedFromTheContainer(string $id, string $expectedType): void
+    {
+        self::assertTrue($this->container->has($id));
+        $instance = $this->container->get($id);
+        self::assertInstanceOf($expectedType, $instance);
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| New Feature   | yes


### Description

Closes #43

Adds an integration test with Laminas ServiceManager _(Adding it as a dev dependency)_ so that we can more easily test the config provider and associated factories will provide the expected instances.