### PR TITLE
Minor refactor of `RouteResult` - add types where missing

### DIFF
--- a/src/Middleware/RouteMiddleware.php
+++ b/src/Middleware/RouteMiddleware.php
@@ -23,12 +23,8 @@ use Psr\Http\Server\RequestHandlerInterface;
  */
 final class RouteMiddleware implements MiddlewareInterface
 {
-    /** @var RouterInterface */
-    protected $router;
-
-    public function __construct(RouterInterface $router)
+    public function __construct(private readonly RouterInterface $router)
     {
-        $this->router = $router;
     }
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface

--- a/src/Route.php
+++ b/src/Route.php
@@ -39,7 +39,7 @@ final class Route implements MiddlewareInterface
     public const HTTP_METHOD_SEPARATOR = ':';
 
     /** @var null|list<string> HTTP methods allowed with this route. */
-    private ?array $methods;
+    private readonly ?array $methods;
 
     /** @var array Options related to this route to pass to the routing implementation. */
     private array $options = [];

--- a/src/RouteCollector.php
+++ b/src/RouteCollector.php
@@ -38,8 +38,8 @@ final class RouteCollector implements RouteCollectorInterface
     private ?DuplicateRouteDetector $duplicateRouteDetector = null;
 
     public function __construct(
-        protected RouterInterface $router,
-        protected bool $detectDuplicates = true
+        private readonly RouterInterface $router,
+        private readonly bool $detectDuplicates = true
     ) {
     }
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

Adds parameter/property/return types where missing and marks a number of properties as readonly.