### PR TITLE
Revert `final` addition to `RuntimeException`

### DIFF
--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -6,6 +6,13 @@ namespace Mezzio\Router\Exception;
 
 use RuntimeException as PhpRuntimeException;
 
-final class RuntimeException extends PhpRuntimeException implements ExceptionInterface
+/**
+ * Generic RuntimeException
+ *
+ * This exception class is extended in router implementation packages.
+ *
+ * @psalm-suppress ClassMustBeFinal
+ */
+class RuntimeException extends PhpRuntimeException implements ExceptionInterface
 {
 }


### PR DESCRIPTION
As the only previously non-final class in the codebase, it was a mistake to finalise this class due to its use in implementation packages

